### PR TITLE
add options to set default Locale

### DIFF
--- a/lib/flutter_i18n.dart
+++ b/lib/flutter_i18n.dart
@@ -19,9 +19,12 @@ class FlutterI18n {
 
   FlutterI18n(this._useCountryCode, [this._fallbackFile, this._basePath]);
 
-  Future<bool> load() async {
+  Future<bool> load([final Locale locale]) async {
     try {
-      await _loadCurrentTranslation();
+      if (locale != null) {
+        this.forcedLocale = true;
+      }
+      await _loadCurrentTranslation(locale);
     } catch (e) {
       await _loadFallback();
     }

--- a/lib/flutter_i18n_delegate.dart
+++ b/lib/flutter_i18n_delegate.dart
@@ -10,12 +10,15 @@ class FlutterI18nDelegate extends LocalizationsDelegate<FlutterI18n> {
   final bool useCountryCode;
   final String fallbackFile;
   final String path;
+  final Locale defaultLocale;
+
   FlutterI18n _currentTranslationObject;
 
   FlutterI18nDelegate(
       {this.useCountryCode = false,
       this.fallbackFile,
-      this.path = "assets/flutter_i18n"});
+      this.path = "assets/flutter_i18n",
+      this.defaultLocale});
 
   @override
   bool isSupported(final Locale locale) {
@@ -28,7 +31,7 @@ class FlutterI18nDelegate extends LocalizationsDelegate<FlutterI18n> {
         _currentTranslationObject.locale != locale) {
       _currentTranslationObject =
           FlutterI18n(useCountryCode, fallbackFile, path);
-      await _currentTranslationObject.load();
+      await _currentTranslationObject.load(defaultLocale);
     }
     return _currentTranslationObject;
   }


### PR DESCRIPTION
Example to set default locale

```dart
import 'package:flutter/material.dart';
import 'package:intl/intl_standalone.dart';

import 'package:flutter_i18n/flutter_i18n_delegate.dart';
import 'package:flutter_localizations/flutter_localizations.dart';

void main() async {
  // set default language or load from configs
  String lan = 'en';
  if (lan == null) {
    // load system locale if lan == null
    final String systemLocale = await findSystemLocale();
    final List<String> systemLocaleSplitted = systemLocale.split('_');
    lan = systemLocaleSplitted[0];
  }

  final FlutterI18nDelegate flutterI18nDelegate = FlutterI18nDelegate(
    useCountryCode: false,
    fallbackFile: 'en',
    path: 'assets/locales',
    defaultLocale: Locale(lan),
  );

  // preload default locale to avoid black screen
  await flutterI18nDelegate.load(null);

  runApp(MyApp(flutterI18nDelegate));
}

class MyApp extends StatelessWidget {
  final FlutterI18nDelegate flutterI18nDelegate;

  MyApp(this.flutterI18nDelegate);

  @override
  Widget build(BuildContext context) {
    return MaterialApp(
      home: Scaffold(
        body: Center(
          child: Text('Test'),
        ),
      ),
      localizationsDelegates: [
        flutterI18nDelegate,
        GlobalMaterialLocalizations.delegate,
        GlobalWidgetsLocalizations.delegate
      ],
    );
  }
}
```