### PR TITLE
allow load translation file according to MaterialApp's locale

### DIFF
--- a/lib/flutter_i18n.dart
+++ b/lib/flutter_i18n.dart
@@ -19,9 +19,9 @@ class FlutterI18n {
 
   FlutterI18n(this._useCountryCode, [this._fallbackFile, this._basePath]);
 
-  Future<bool> load() async {
+  Future<bool> load([Locale locale]) async {
     try {
-      await _loadCurrentTranslation();
+      await _loadCurrentTranslation(locale);
     } catch (e) {
       await _loadFallback();
     }

--- a/lib/flutter_i18n_delegate.dart
+++ b/lib/flutter_i18n_delegate.dart
@@ -28,7 +28,7 @@ class FlutterI18nDelegate extends LocalizationsDelegate<FlutterI18n> {
         FlutterI18nDelegate._currentTranslationObject.locale != locale) {
       FlutterI18nDelegate._currentTranslationObject =
           FlutterI18n(useCountryCode, fallbackFile, path);
-      await FlutterI18nDelegate._currentTranslationObject.load();
+      await FlutterI18nDelegate._currentTranslationObject.load(locale);
     }
     return FlutterI18nDelegate._currentTranslationObject;
   }


### PR DESCRIPTION
allow load translation file according to MaterialApp's locale (instead of always load system's locale)

Example:

```
MaterialApp(
    locale: _locale,           // <-- FlutterI18nDelegate should load file according to this setting
    localizationsDelegates: [
        FlutterI18nDelegate(
            useCountryCode: false,
            fallbackFile: 'en',
            path: 'assets/flutter_i18n'),
        GlobalMaterialLocalizations.delegate,
        GlobalWidgetsLocalizations.delegate,
        GlobalCupertinoLocalizations.delegate,
      ],
)
```