### PR TITLE
Fix an issue with throwing exceptions on YAML load

### DIFF
--- a/lib/flutter_i18n.dart
+++ b/lib/flutter_i18n.dart
@@ -1,5 +1,6 @@
 import 'dart:async';
 import 'dart:convert';
+import 'dart:io';
 
 import 'package:flutter/services.dart';
 import 'package:flutter/services.dart' show rootBundle;
@@ -56,13 +57,17 @@ class FlutterI18n {
   }
 
   Future<void> _loadFile(final String fileName) async {
-    try {
+    final jsonPath = '$_basePath/$fileName.json';
+    final yamlPath = '$_basePath/$fileName.yaml';
+
+    final jsonExists = await File(jsonPath).exists();
+    if (jsonExists) {
       decodedMap = await rootBundle
-          .loadString('$_basePath/$fileName.json')
+          .loadString(jsonPath)
           .then((jsonString) => json.decode(jsonString));
-    } on FlutterError catch (_) {
+    } else {
       var yamlNode = await rootBundle
-          .loadString('$_basePath/$fileName.yaml')
+          .loadString(yamlPath)
           .then((yamlString) => loadYamlNode(yamlString));
       decodedMap = _convertYaml(yamlNode);
     }


### PR DESCRIPTION
Fixes #52 #15 

Instead of trying to load a file which may not exist and catch an exception I suggest to check whether a file exists or not first.
I tested the patch on my project and it works good.