### PR TITLE
Added I18nBuilder

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,32 @@ I18nPlural("clicked.times", 1)
 I18nPlural("clicked.times", 2, child: Text(""))
 ```
 
+It's also possible to use `I18nBuilder` to rebuild the widget tree in response to locale changes. If you want to rebuild your whole app you can do this:
+
+```dart
+I18nBuilder(
+  translationObject: flutterI18nDelegate.translationObject,
+  builder: (context, locale) => MaterialApp(
+    locale: locale,
+    home: MyHomePage(),
+    localizationsDelegates: [
+      flutterI18nDelegate,
+      GlobalMaterialLocalizations.delegate,
+      GlobalWidgetsLocalizations.delegate
+    ],
+)
+```
+
+or if your context has an ancestor of `FlutterI18n` there is no need to provide `translationObject`:
+
+```dart
+I18nBuilder(
+  builder: (context, _) => Text(FlutterI18n.translate(
+      context, 'label.main',
+      translationParams: {"user": "Flutter lover"})),
+)
+```
+
 If you need to listen the translation loading status, you can use:
 - ```FlutterI18n.retrieveLoadingStream``` method, that allows you to listen to every status change
 - ```FlutterI18n.retrieveLoadedStream``` method, that allows you to listen when the translation is loaded

--- a/lib/flutter_i18n.dart
+++ b/lib/flutter_i18n.dart
@@ -19,6 +19,7 @@ export 'loaders/network_file_translation_loader.dart';
 export 'loaders/translation_loader.dart';
 export 'widgets/I18nPlural.dart';
 export 'widgets/I18nText.dart';
+export 'widgets/I18nBuilder.dart';
 
 typedef void MissingTranslationHandler(String key, Locale locale);
 
@@ -31,8 +32,11 @@ class FlutterI18n {
   Map<dynamic, dynamic> decodedMap;
 
   final _localeStream = StreamController<Locale>.broadcast();
+
   // ignore: close_sinks
   final _loadingStream = StreamController<LoadingStatus>.broadcast();
+
+  Stream<Locale> get localeStream => _localeStream.stream;
 
   Stream<LoadingStatus> get loadingStream => _loadingStream.stream;
 
@@ -67,7 +71,7 @@ class FlutterI18n {
   /// Facade method to the plural translation logic
   static String plural(final BuildContext context, final String translationKey,
       final int pluralValue) {
-    final FlutterI18n currentInstance = _retrieveCurrentInstance(context);
+    final FlutterI18n currentInstance = FlutterI18n.of(context);
     final PluralTranslator pluralTranslator = PluralTranslator(
       currentInstance.decodedMap,
       translationKey,
@@ -83,7 +87,7 @@ class FlutterI18n {
   /// Facade method to force the load of a new locale
   static Future refresh(
       final BuildContext context, final Locale forcedLocale) async {
-    final FlutterI18n currentInstance = _retrieveCurrentInstance(context);
+    final FlutterI18n currentInstance = FlutterI18n.of(context);
     currentInstance.translationLoader.forcedLocale = forcedLocale;
     await currentInstance.load();
   }
@@ -91,7 +95,7 @@ class FlutterI18n {
   /// Facade method to the simple translation logic
   static String translate(final BuildContext context, final String key,
       {final String fallbackKey, final Map<String, String> translationParams}) {
-    final FlutterI18n currentInstance = _retrieveCurrentInstance(context);
+    final FlutterI18n currentInstance = FlutterI18n.of(context);
     final SimpleTranslator simpleTranslator = SimpleTranslator(
       currentInstance.decodedMap,
       key,
@@ -107,18 +111,18 @@ class FlutterI18n {
 
   /// Same as `get locale`, but this can be invoked from widgets
   static Locale currentLocale(final BuildContext context) {
-    final FlutterI18n currentInstance = _retrieveCurrentInstance(context);
+    final FlutterI18n currentInstance = FlutterI18n.of(context);
     return currentInstance?.translationLoader?.locale;
   }
 
-  static FlutterI18n _retrieveCurrentInstance(BuildContext context) {
+  static FlutterI18n of(BuildContext context) {
     return Localizations.of<FlutterI18n>(context, FlutterI18n);
   }
 
   /// Build for root widget, to support RTL languages
   static rootAppBuilder() {
     return (BuildContext context, Widget child) {
-      final instance = _retrieveCurrentInstance(context);
+      final instance = FlutterI18n.of(context);
       return StreamBuilder<Locale>(
           initialData: instance?.locale,
           stream: instance?._localeStream?.stream,
@@ -134,12 +138,12 @@ class FlutterI18n {
   /// Used to retrieve the loading status stream
   static Stream<LoadingStatus> retrieveLoadingStream(
       final BuildContext context) {
-    return _retrieveCurrentInstance(context).loadingStream;
+    return FlutterI18n.of(context).loadingStream;
   }
 
   /// Used to check if the translation file is still loading
   static Stream<bool> retrieveLoadedStream(final BuildContext context) {
-    return _retrieveCurrentInstance(context).isLoadedStream;
+    return FlutterI18n.of(context).isLoadedStream;
   }
 
   static _findTextDirection(final Locale locale) {

--- a/lib/flutter_i18n.dart
+++ b/lib/flutter_i18n.dart
@@ -17,9 +17,9 @@ export 'loaders/file_translation_loader.dart';
 export 'loaders/namespace_file_translation_loader.dart';
 export 'loaders/network_file_translation_loader.dart';
 export 'loaders/translation_loader.dart';
+export 'widgets/I18nBuilder.dart';
 export 'widgets/I18nPlural.dart';
 export 'widgets/I18nText.dart';
-export 'widgets/I18nBuilder.dart';
 
 typedef void MissingTranslationHandler(String key, Locale locale);
 
@@ -71,7 +71,7 @@ class FlutterI18n {
   /// Facade method to the plural translation logic
   static String plural(final BuildContext context, final String translationKey,
       final int pluralValue) {
-    final FlutterI18n currentInstance = FlutterI18n.of(context);
+    final FlutterI18n currentInstance = of(context);
     final PluralTranslator pluralTranslator = PluralTranslator(
       currentInstance.decodedMap,
       translationKey,
@@ -87,7 +87,7 @@ class FlutterI18n {
   /// Facade method to force the load of a new locale
   static Future refresh(
       final BuildContext context, final Locale forcedLocale) async {
-    final FlutterI18n currentInstance = FlutterI18n.of(context);
+    final FlutterI18n currentInstance = of(context);
     currentInstance.translationLoader.forcedLocale = forcedLocale;
     await currentInstance.load();
   }
@@ -95,7 +95,7 @@ class FlutterI18n {
   /// Facade method to the simple translation logic
   static String translate(final BuildContext context, final String key,
       {final String fallbackKey, final Map<String, String> translationParams}) {
-    final FlutterI18n currentInstance = FlutterI18n.of(context);
+    final FlutterI18n currentInstance = of(context);
     final SimpleTranslator simpleTranslator = SimpleTranslator(
       currentInstance.decodedMap,
       key,
@@ -111,7 +111,7 @@ class FlutterI18n {
 
   /// Same as `get locale`, but this can be invoked from widgets
   static Locale currentLocale(final BuildContext context) {
-    final FlutterI18n currentInstance = FlutterI18n.of(context);
+    final FlutterI18n currentInstance = of(context);
     return currentInstance?.translationLoader?.locale;
   }
 
@@ -122,7 +122,7 @@ class FlutterI18n {
   /// Build for root widget, to support RTL languages
   static rootAppBuilder() {
     return (BuildContext context, Widget child) {
-      final instance = FlutterI18n.of(context);
+      final instance = of(context);
       return StreamBuilder<Locale>(
           initialData: instance?.locale,
           stream: instance?._localeStream?.stream,
@@ -138,12 +138,12 @@ class FlutterI18n {
   /// Used to retrieve the loading status stream
   static Stream<LoadingStatus> retrieveLoadingStream(
       final BuildContext context) {
-    return FlutterI18n.of(context).loadingStream;
+    return of(context).loadingStream;
   }
 
   /// Used to check if the translation file is still loading
   static Stream<bool> retrieveLoadedStream(final BuildContext context) {
-    return FlutterI18n.of(context).isLoadedStream;
+    return of(context).isLoadedStream;
   }
 
   static _findTextDirection(final Locale locale) {

--- a/lib/flutter_i18n_delegate.dart
+++ b/lib/flutter_i18n_delegate.dart
@@ -8,19 +8,20 @@ import 'flutter_i18n.dart';
 
 /// Translation delegate that manage the new locale received from the framework
 class FlutterI18nDelegate extends LocalizationsDelegate<FlutterI18n> {
-  static FlutterI18n _translationObject;
+  final FlutterI18n _translationObject;
   Locale currentLocale;
+
+  FlutterI18n get translationObject => _translationObject;
 
   FlutterI18nDelegate(
       {translationLoader,
       MissingTranslationHandler missingTranslationHandler,
-      String keySeparator = "."}) {
-    _translationObject = FlutterI18n(
-      translationLoader,
-      keySeparator,
-      missingTranslationHandler: missingTranslationHandler,
-    );
-  }
+      String keySeparator = "."})
+      : _translationObject = FlutterI18n(
+          translationLoader,
+          keySeparator,
+          missingTranslationHandler: missingTranslationHandler,
+        );
 
   @override
   bool isSupported(final Locale locale) {

--- a/lib/widgets/I18nBuilder.dart
+++ b/lib/widgets/I18nBuilder.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_i18n/flutter_i18n.dart';
+
+typedef FlutterI18nWidgetBuilder = Widget Function(BuildContext context, Locale locale);
+
+class I18nBuilder extends StatelessWidget {
+  final FlutterI18n _translationObject;
+  final FlutterI18nWidgetBuilder builder;
+
+  I18nBuilder({this.builder, FlutterI18n translationObject, Key key})
+      : _translationObject = translationObject,
+        super(key: key);
+
+  @override
+  Widget build(BuildContext context) {
+    final translationObject = _translationObject ?? FlutterI18n.of(context);
+    return StreamBuilder<Locale>(
+        stream: translationObject.localeStream.distinct(),
+        builder: (context, snapshot) => builder(context, snapshot.data));
+  }
+}


### PR DESCRIPTION
Added a builder widget which will be useful in cases where we want to rebuild some part of widget tree in response to locale changes.

Example1 (This way there is no need for `rootAppBuilder` and `setState` when developer uses `refresh` method since `MaterialApp` will take care of direction changes and also the whole widget tree will rebuild):
```
I18nBuilder(
  translationObject: flutterI18nDelegate.translationObject,
  builder: (context, locale) => MaterialApp(
    locale: locale,
    home: MyHomePage(),
    localizationsDelegates: [
      flutterI18nDelegate,
      GlobalMaterialLocalizations.delegate,
      GlobalWidgetsLocalizations.delegate
    ],
)
```

Example2:
```
I18nBuilder(
  builder: (context, _) => Text(FlutterI18n.translate(
      context, 'label.main',
      translationParams: {"user": "Flutter lover"})),
)
```