### PR TITLE
Translate without context

### DIFF
--- a/lib/flutter_i18n.dart
+++ b/lib/flutter_i18n.dart
@@ -35,7 +35,7 @@ class FlutterI18n {
   // ignore: close_sinks
   final _loadingStream = StreamController<LoadingStatus>.broadcast();
 
-  FlutterI18n of(BuildContext context) => _retrieveCurrentInstance(context)!;
+  static FlutterI18n of(BuildContext context) => _retrieveCurrentInstance(context)!;
 
   Stream<LoadingStatus> get loadingStream => _loadingStream.stream;
 

--- a/lib/flutter_i18n.dart
+++ b/lib/flutter_i18n.dart
@@ -35,6 +35,8 @@ class FlutterI18n {
   // ignore: close_sinks
   final _loadingStream = StreamController<LoadingStatus>.broadcast();
 
+  FlutterI18n of(BuildContext context) => _retrieveCurrentInstance(context)!;
+
   Stream<LoadingStatus> get loadingStream => _loadingStream.stream;
 
   Stream<bool> get isLoadedStream => loadingStream
@@ -101,6 +103,24 @@ class FlutterI18n {
       translationParams: translationParams,
       missingKeyTranslationHandler: (key) {
         currentInstance.missingTranslationHandler(key, currentInstance.locale);
+      },
+    );
+    return simpleTranslator.translate();
+  }
+
+  /// Facade method to the simple translation logic that uses provided FlutterI18n instance
+  /// Meant to be used with some dependency injection tool such as GetIt to avoid need for context
+  static String translateWithInstance(final FlutterI18n instance, final String key,
+      {final String? fallbackKey,
+        final Map<String, String>? translationParams}) {
+    final SimpleTranslator simpleTranslator = SimpleTranslator(
+      instance.decodedMap,
+      key,
+      instance.keySeparator,
+      fallbackKey: fallbackKey,
+      translationParams: translationParams,
+      missingKeyTranslationHandler: (key) {
+        instance.missingTranslationHandler(key, instance.locale);
       },
     );
     return simpleTranslator.translate();


### PR DESCRIPTION
Hi,
First of all thanks for an amazing package. I've been using it for a while and it's worked just great.

At work, I got a task which required me to assign a default name to a file, which had to be different depending on the user's language preferences. This is supposed to be done in the data layer, at least that's where we do it. 

If we were to continue using FlutterI18n to do it, we would have to find a way to inject the BuildContext all the way down to the data layer, which would make a real mess in our codebase. So, I've decided to make a PR to enable getting an FlutterI18n instance without BuildContext. It's not completely ruled out, you still need it when registering the service, but that's about it.

We use get_it for dependency injection so we just register FlutterI18n at app start, and then fetch it wherever we need it, eg.


```
if (!injector.isRegistered<FlutterI18n>()) {
    injector.registerLazySingleton<FlutterI18n>(() => FlutterI18n.of(context));
  }
```

you retrieve it like this: 

`FlutterI18n instance = GetIt.instance.get();` 

and you can use it like this:

`String translation = FlutterI18n.translateWithInstance(instance, key);`

and that's about it.

translateWithInstance(..) is the method that's I've added to avoid making any breaking changes by editing the existing translate() method.