### PR TITLE
Enable translation without context

### DIFF
--- a/lib/flutter_i18n.dart
+++ b/lib/flutter_i18n.dart
@@ -35,7 +35,7 @@ class FlutterI18n {
   // ignore: close_sinks
   final _loadingStream = StreamController<LoadingStatus>.broadcast();
 
-  FlutterI18n of(BuildContext context) => _retrieveCurrentInstance(context)!;
+  static FlutterI18n of(BuildContext context) => _retrieveCurrentInstance(context)!;
 
   Stream<LoadingStatus> get loadingStream => _loadingStream.stream;
 

--- a/lib/flutter_i18n.dart
+++ b/lib/flutter_i18n.dart
@@ -39,8 +39,7 @@ class FlutterI18n {
 
   Stream<LoadingStatus> get loadingStream => _loadingStream.stream;
 
-  Stream<bool> get isLoadedStream => loadingStream
-      .map((loadingStatus) => loadingStatus == LoadingStatus.loaded);
+  Stream<bool> get isLoadedStream => loadingStream.map((loadingStatus) => loadingStatus == LoadingStatus.loaded);
 
   FlutterI18n(
     TranslationLoader? translationLoader,
@@ -49,8 +48,7 @@ class FlutterI18n {
   }) {
     this.translationLoader = translationLoader ?? FileTranslationLoader();
     this._loadingStream.add(LoadingStatus.notLoaded);
-    this.missingTranslationHandler =
-        missingTranslationHandler ?? (key, locale) {};
+    this.missingTranslationHandler = missingTranslationHandler ?? (key, locale) {};
     this.keySeparator = keySeparator;
   }
 
@@ -67,9 +65,9 @@ class FlutterI18n {
   get locale => this.translationLoader!.locale;
 
   /// Facade method to the plural translation logic
-  static String plural(final BuildContext context, final String translationKey,
-      final int pluralValue) {
-    final FlutterI18n currentInstance = _retrieveCurrentInstance(context)!;
+  static String plural(final BuildContext context, final String translationKey, final int pluralValue,
+      {final FlutterI18n? instance}) {
+    final FlutterI18n currentInstance = instance ?? _retrieveCurrentInstance(context)!;
     final PluralTranslator pluralTranslator = PluralTranslator(
       currentInstance.decodedMap,
       translationKey,
@@ -83,18 +81,16 @@ class FlutterI18n {
   }
 
   /// Facade method to force the load of a new locale
-  static Future refresh(
-      final BuildContext context, final Locale? forcedLocale) async {
-    final FlutterI18n currentInstance = _retrieveCurrentInstance(context)!;
+  static Future refresh(final BuildContext context, final Locale? forcedLocale, {final FlutterI18n? instance}) async {
+    final FlutterI18n currentInstance = instance ?? _retrieveCurrentInstance(context)!;
     currentInstance.translationLoader!.forcedLocale = forcedLocale;
     await currentInstance.load();
   }
 
   /// Facade method to the simple translation logic
   static String translate(final BuildContext context, final String key,
-      {final String? fallbackKey,
-      final Map<String, String>? translationParams}) {
-    final FlutterI18n currentInstance = _retrieveCurrentInstance(context)!;
+      {final FlutterI18n? instance, final String? fallbackKey, final Map<String, String>? translationParams}) {
+    final FlutterI18n currentInstance = instance ?? _retrieveCurrentInstance(context)!;
     final SimpleTranslator simpleTranslator = SimpleTranslator(
       currentInstance.decodedMap,
       key,
@@ -108,27 +104,9 @@ class FlutterI18n {
     return simpleTranslator.translate();
   }
 
-  /// Facade method to the simple translation logic that uses provided FlutterI18n instance
-  /// Meant to be used with some dependency injection tool such as GetIt to avoid need for context
-  static String translateWithInstance(final FlutterI18n instance, final String key,
-      {final String? fallbackKey,
-        final Map<String, String>? translationParams}) {
-    final SimpleTranslator simpleTranslator = SimpleTranslator(
-      instance.decodedMap,
-      key,
-      instance.keySeparator,
-      fallbackKey: fallbackKey,
-      translationParams: translationParams,
-      missingKeyTranslationHandler: (key) {
-        instance.missingTranslationHandler(key, instance.locale);
-      },
-    );
-    return simpleTranslator.translate();
-  }
-
   /// Same as `get locale`, but this can be invoked from widgets
-  static Locale? currentLocale(final BuildContext context) {
-    final FlutterI18n? currentInstance = _retrieveCurrentInstance(context);
+  static Locale? currentLocale(final BuildContext context, {final FlutterI18n? instance}) {
+    final FlutterI18n? currentInstance = instance ?? _retrieveCurrentInstance(context);
     return currentInstance?.translationLoader?.locale;
   }
 
@@ -157,8 +135,7 @@ class FlutterI18n {
   }
 
   /// Used to retrieve the loading status stream
-  static Stream<LoadingStatus> retrieveLoadingStream(
-      final BuildContext context) {
+  static Stream<LoadingStatus> retrieveLoadingStream(final BuildContext context) {
     return _retrieveCurrentInstance(context)!.loadingStream;
   }
 
@@ -168,8 +145,6 @@ class FlutterI18n {
   }
 
   static TextDirection _findTextDirection(final Locale? locale) {
-    return intl.Bidi.isRtlLanguage(locale?.languageCode)
-        ? TextDirection.rtl
-        : TextDirection.ltr;
+    return intl.Bidi.isRtlLanguage(locale?.languageCode) ? TextDirection.rtl : TextDirection.ltr;
   }
 }

--- a/lib/flutter_i18n.dart
+++ b/lib/flutter_i18n.dart
@@ -35,6 +35,8 @@ class FlutterI18n {
   // ignore: close_sinks
   final _loadingStream = StreamController<LoadingStatus>.broadcast();
 
+  FlutterI18n of(BuildContext context) => _retrieveCurrentInstance(context)!;
+
   Stream<LoadingStatus> get loadingStream => _loadingStream.stream;
 
   Stream<bool> get isLoadedStream => loadingStream
@@ -101,6 +103,24 @@ class FlutterI18n {
       translationParams: translationParams,
       missingKeyTranslationHandler: (key) {
         currentInstance.missingTranslationHandler(key, currentInstance.locale);
+      },
+    );
+    return simpleTranslator.translate();
+  }
+
+  /// Facade method to the simple translation logic that uses provided FlutterI18n instance
+  /// Meant to be used with some dependency injection tool such as GetIt to avoid need for context
+  static String translateWithInstance(final FlutterI18n instance, final String key,
+      {final String? fallbackKey,
+        final Map<String, String>? translationParams}) {
+    final SimpleTranslator simpleTranslator = SimpleTranslator(
+      instance.decodedMap,
+      key,
+      instance.keySeparator,
+      fallbackKey: fallbackKey,
+      translationParams: translationParams,
+      missingKeyTranslationHandler: (key) {
+        instance.missingTranslationHandler(key, instance.locale);
       },
     );
     return simpleTranslator.translate();

--- a/lib/flutter_i18n.dart
+++ b/lib/flutter_i18n.dart
@@ -65,9 +65,9 @@ class FlutterI18n {
   get locale => this.translationLoader!.locale;
 
   /// Facade method to the plural translation logic
-  static String plural(final BuildContext context, final String translationKey, final int pluralValue,
+  static String plural(final BuildContext? context, final String translationKey, final int pluralValue,
       {final FlutterI18n? instance}) {
-    final FlutterI18n currentInstance = instance ?? _retrieveCurrentInstance(context)!;
+    final FlutterI18n currentInstance = instance ?? _retrieveCurrentInstance(context!)!;
     final PluralTranslator pluralTranslator = PluralTranslator(
       currentInstance.decodedMap,
       translationKey,
@@ -81,16 +81,16 @@ class FlutterI18n {
   }
 
   /// Facade method to force the load of a new locale
-  static Future refresh(final BuildContext context, final Locale? forcedLocale, {final FlutterI18n? instance}) async {
-    final FlutterI18n currentInstance = instance ?? _retrieveCurrentInstance(context)!;
+  static Future refresh(final BuildContext? context, final Locale? forcedLocale, {final FlutterI18n? instance}) async {
+    final FlutterI18n currentInstance = instance ?? _retrieveCurrentInstance(context!)!;
     currentInstance.translationLoader!.forcedLocale = forcedLocale;
     await currentInstance.load();
   }
 
   /// Facade method to the simple translation logic
-  static String translate(final BuildContext context, final String key,
+  static String translate(final BuildContext? context, final String key,
       {final FlutterI18n? instance, final String? fallbackKey, final Map<String, String>? translationParams}) {
-    final FlutterI18n currentInstance = instance ?? _retrieveCurrentInstance(context)!;
+    final FlutterI18n currentInstance = instance ?? _retrieveCurrentInstance(context!)!;
     final SimpleTranslator simpleTranslator = SimpleTranslator(
       currentInstance.decodedMap,
       key,
@@ -105,8 +105,8 @@ class FlutterI18n {
   }
 
   /// Same as `get locale`, but this can be invoked from widgets
-  static Locale? currentLocale(final BuildContext context, {final FlutterI18n? instance}) {
-    final FlutterI18n? currentInstance = instance ?? _retrieveCurrentInstance(context);
+  static Locale? currentLocale(final BuildContext? context, {final FlutterI18n? instance}) {
+    final FlutterI18n? currentInstance = instance ?? _retrieveCurrentInstance(context!);
     return currentInstance?.translationLoader?.locale;
   }
 

--- a/lib/widgets/I18nPlural.dart
+++ b/lib/widgets/I18nPlural.dart
@@ -6,14 +6,15 @@ class I18nPlural extends StatelessWidget {
   final String _key;
   final int _pluralValue;
   final Text child;
+  final FlutterI18n? instance;
   static const _default_text = Text("");
 
-  I18nPlural(this._key, this._pluralValue, {this.child = _default_text});
+  I18nPlural(this._key, this._pluralValue, {this.child = _default_text, this.instance});
 
   @override
   Widget build(BuildContext context) {
     return Text(
-      FlutterI18n.plural(context, _key, _pluralValue),
+      FlutterI18n.plural(context, _key, _pluralValue, instance: instance),
       key: child.key,
       style: child.style,
       strutStyle: child.strutStyle,

--- a/lib/widgets/I18nText.dart
+++ b/lib/widgets/I18nText.dart
@@ -6,17 +6,17 @@ class I18nText extends StatelessWidget {
   final String _key;
   final Text child;
   final String? fallbackKey;
+  final FlutterI18n? instance;
   final Map<String, String>? translationParams;
   static const _default_text = Text("");
 
-  I18nText(this._key,
-      {this.child = _default_text, this.fallbackKey, this.translationParams});
+  I18nText(this._key, {this.child = _default_text, this.fallbackKey, this.translationParams, this.instance});
 
   @override
   Widget build(BuildContext context) {
     return Text(
       FlutterI18n.translate(context, _key,
-          fallbackKey: fallbackKey, translationParams: translationParams),
+          fallbackKey: fallbackKey, translationParams: translationParams, instance: instance),
       key: child.key,
       style: child.style,
       strutStyle: child.strutStyle,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -112,6 +112,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.12.11"
+  material_color_utilities:
+    dependency: transitive
+    description:
+      name: material_color_utilities
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.1.3"
   meta:
     dependency: transitive
     description:
@@ -193,7 +200,7 @@ packages:
       name: test_api
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.4.3"
+    version: "0.4.8"
   toml:
     dependency: "direct main"
     description:

--- a/test/text_widget_no_context.dart
+++ b/test/text_widget_no_context.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_i18n/flutter_i18n.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+
+import './test_loader.dart';
+
+FlutterI18n? instance;
+
+class TestWidgetNoContext extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    final FlutterI18nDelegate flutterI18nDelegate = FlutterI18nDelegate(
+      translationLoader: TestJsonLoader(
+          useCountryCode: false,
+          fallbackFile: 'en',
+          basePath: 'assets/i18n',
+          forcedLocale: Locale('en')),
+    );
+
+    return MaterialApp(
+        title: 'Flutter Demo',
+        localizationsDelegates: [
+          flutterI18nDelegate,
+          GlobalMaterialLocalizations.delegate,
+          GlobalWidgetsLocalizations.delegate
+        ],
+        home: TestWidgetNoContextPage(),
+        builder: (context, child) {
+          instance = FlutterI18n.of(context);
+          return child!;
+        },
+    );
+  }
+}
+
+class TestWidgetNoContextPage extends StatefulWidget {
+  @override
+  createState() => TestWidgetNoContextPageState();
+}
+
+class TestWidgetNoContextPageState extends State<TestWidgetNoContextPage> {
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+        appBar: AppBar(
+          title: Text("Test"),
+        ),
+        body: Builder(builder: (context) {
+          return Center(
+            child: Column(
+              children: <Widget>[
+                I18nText("keySingle", instance: instance),
+                I18nPlural("keyPlural", 1, child: Text(""), instance: instance),
+                I18nPlural("keyPlural", 2, instance: instance),
+                I18nText("object.key1", instance: instance),
+                I18nText("object", instance: instance),
+                I18nText("object", fallbackKey: "fileName", instance: instance),
+                ElevatedButton(
+                  onPressed: () async {
+                    var locale = FlutterI18n.currentLocale(context, instance: instance);
+                    await FlutterI18n.refresh(context, locale, instance: instance);
+                  }, child: null,
+                ),
+              ],
+            ),
+          );
+        }));
+  }
+}

--- a/test/widgets/I18nPlural_no_context_test.dart
+++ b/test/widgets/I18nPlural_no_context_test.dart
@@ -1,0 +1,29 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import '../text_widget_no_context.dart';
+
+void main() {
+  testWidgets(
+      'TestWidget with I18nPlural should translate text with `1` plural value',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(TestWidgetNoContext());
+        await tester.pump();
+
+        expect(find.text('valuePlural-1'), findsOneWidget);
+        expect(find.text('valuePlural'), findsNothing);
+        expect(find.text('keyPlural'), findsNothing);
+        expect(find.text('keyPlural-1'), findsNothing);
+      });
+
+  testWidgets(
+      'TestWidget with I18nPlural should translate text with `2` plural value',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(TestWidgetNoContext());
+        await tester.pump();
+
+        expect(find.text('valuePlural-2'), findsOneWidget);
+        expect(find.text('valuePlural'), findsNothing);
+        expect(find.text('keyPlural'), findsNothing);
+        expect(find.text('keyPlural-2'), findsNothing);
+      });
+}

--- a/test/widgets/I18nText_no_context_test.dart
+++ b/test/widgets/I18nText_no_context_test.dart
@@ -1,0 +1,37 @@
+
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+import '../text_widget_no_context.dart';
+
+void main() {
+  testWidgets('TestWidget with I18nText should translate text',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(TestWidgetNoContext());
+        await tester.pump();
+
+        final valueFinder = find.text('valueSingle');
+        final keyFinder = find.text('keySingle');
+
+        expect(valueFinder, findsOneWidget);
+        expect(keyFinder, findsNothing);
+      });
+
+  testWidgets('TestWidget should reload language', (WidgetTester tester) async {
+    await tester.pumpWidget(TestWidgetNoContext());
+    await tester.pump();
+
+    await tester.tap(find.byType(ElevatedButton));
+  });
+
+  testWidgets('a key that point to an object must return the key itself',
+          (WidgetTester tester) async {
+        await tester.pumpWidget(TestWidgetNoContext());
+        await tester.pump();
+
+        expect(find.text('Key1Value'), findsOneWidget);
+        expect(find.text('Key2Value'), findsNothing);
+        expect(find.text('object'), findsOneWidget);
+        expect(find.text('en'), findsOneWidget);
+      });
+}


### PR DESCRIPTION
Hi, I just completed the PR that enables translation with FlutterI18n instance, and without context. Basically I made BuildContext nullable in 4 functions that required it: translate(..), plural(..), currentLocale(..) and refresh(..). I added an optional named parameter FlutterI18n? instance to all of these, and have added it to I18nText and I18nPlural widgets as well. I decided to go with this kind of implementation to avoid adding additional 4 functions to the FlutterI18n class. IMHO it would make it too bloated. I am not completely satisfied with this solution either, since you need to pass null for BuildContext each time you translate without it, but I didn't have any better ideas how to implement it.

I have added tests as well.

Now you can register a FlutterI18n instance, and call for translator, for instance, somewhere in your data layer, like this:

```
FlutterI18n instance = GetIt.instance.get();
String translatedText = FlutterI18n.translate(null, 'translation_key', instance: instance);  
```

Whenever you pass an instance that is not null it will avoid trying to use the context. When instance is not passed context is used. Developers must take care not to set both BuildContext and instance to null.