### PR TITLE
Fix TypeError in calculateSubmap 

### DIFF
--- a/lib/utils/simple_translator.dart
+++ b/lib/utils/simple_translator.dart
@@ -63,8 +63,10 @@ class SimpleTranslator {
         translationKey.split(this.keySeparator!);
     translationKeySplitted.removeLast();
     Map<dynamic, dynamic>? decodedSubMap = decodedMap;
-    translationKeySplitted.forEach((listKey) =>
-        decodedSubMap = (decodedSubMap ?? Map())[listKey] ?? Map());
+    translationKeySplitted.forEach((listKey) {
+      final subMap = (decodedSubMap ?? Map())[listKey];
+      decodedSubMap = subMap is Map ? subMap : Map();
+    });
     return decodedSubMap ?? {};
   }
 }

--- a/test/utils/simple_translator_test.dart
+++ b/test/utils/simple_translator_test.dart
@@ -65,5 +65,34 @@ void main() {
       final submap = instance.calculateSubmap('');
       expect(submap, {});
     });
+
+    test('should return empty submap when the value of nested key is not a Map', () {
+      final instance = SimpleTranslator(
+        {
+          'object': {
+            'key1': 'value1',
+          },
+        },
+        'object.key1.key2',
+        '.',
+      );
+      final subMap = instance.calculateSubmap('object.key1.key2');
+      expect(subMap, {});
+    });
+
+    test('should return key when the value of nested key is not a Map', () {
+      final instance = SimpleTranslator(
+        {
+          'object': {
+            'key1': 'value1',
+          },
+        },
+        'object.key1.key2',
+        '.',
+        missingKeyTranslationHandler: (key) {},
+      );
+      final translation = instance.translate();
+      expect(translation, 'object.key1.key2');
+    });
   });
 }


### PR DESCRIPTION
### The Problem

I wanted to upgrade versions in an old template project of my company which uses `flutter_i18n` for the translations and i ran into this error: 
```
type 'String' is not a subtype of type 'Map<dynamic, dynamic>?'

When the exception was thrown, this was the stack:
#0      SimpleTranslator.calculateSubmap.<anonymous closure> (package:flutter_i18n/utils/simple_translator.dart:60:49)
#1      List.forEach (dart:core-patch/growable_array.dart:416:8)
#2      SimpleTranslator.calculateSubmap (package:flutter_i18n/utils/simple_translator.dart:60:28)
#3      SimpleTranslator._decodeFromMap (package:flutter_i18n/utils/simple_translator.dart:45:42)
```
Based on the stack, i started to search for the problem in the  `SimpleTranslator` and i found out that the problem was that we had two locale files which were different:
```dart
// en.json
{
 "fields": {
    "email": {
      "label": "Your email address",
      "mandatory_error": "Please enter your email",
      "invalid_email": "Please enter a valid email address",
      "email_taken": "This email address is already registered."
  }
  ...
}

// hu.json
{
 "fields": {
    "email": "Email cím",
    ...
}
```

And we used the `fields.email.label` key everywhere but it looks like we forgot to check if everything works with the other language too since it's just a template project. So the problem is that the `calculateSubmap`'s return type is `Map<dynamic, dynamic>` but the value of the key for the other language is not a `Map`  but a `String` which causes this error.

It looks a minor problem that can be fixed by adding the proper translations to the `json` files but if somebody forget it then the error message is not really useful to find the problem. So now it checks if the value is a `Map` or not and it will gives back an empty `Map` is it's not. By this, it will just call the `missingKeyTranslationHandler` and shows the key that you passed.
 