### PR TITLE
Updating dependencies (allowing support toml ^0.13.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -268,3 +268,6 @@ Fix for #190
 
 ## [0.32.3]
 Fix for #197 and #196
+
+## [0.32.4]
+Dependencies upgrade

--- a/bin/flutter_i18n.dart
+++ b/bin/flutter_i18n.dart
@@ -1,5 +1,3 @@
-import 'package:flutter_i18n/utils/message_printer.dart';
-
 import 'actions/ActionInterface.dart';
 import 'actions/DiffAction.dart';
 import 'actions/ValidateAction.dart';

--- a/example/lib/basic_example.dart
+++ b/example/lib/basic_example.dart
@@ -2,8 +2,6 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_i18n/flutter_i18n.dart';
-import 'package:flutter_i18n/widgets/I18nPlural.dart';
-import 'package:flutter_i18n/widgets/I18nText.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 
 Future main() async {

--- a/example/lib/local_example.dart
+++ b/example/lib/local_example.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 import 'dart:io';
 
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_i18n/flutter_i18n_delegate.dart';
 import 'package:flutter_i18n/loaders/decoders/json_decode_strategy.dart';

--- a/example/lib/namespace_example.dart
+++ b/example/lib/namespace_example.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 
 import 'package:flutter/material.dart';
 import 'package:flutter_i18n/flutter_i18n.dart';
-import 'package:flutter_i18n/widgets/I18nText.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 
 Future main() async {

--- a/example/lib/network_example.dart
+++ b/example/lib/network_example.dart
@@ -3,7 +3,6 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_i18n/flutter_i18n.dart';
 import 'package:flutter_i18n/loaders/decoders/json_decode_strategy.dart';
-import 'package:flutter_i18n/widgets/I18nText.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 
 class CustomNetworkFileTranslationLoader extends NetworkFileTranslationLoader {

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -136,7 +136,7 @@ packages:
       path: ".."
       relative: true
     source: path
-    version: "0.32.3"
+    version: "0.32.4"
   flutter_localizations:
     dependency: transitive
     description: flutter
@@ -329,7 +329,7 @@ packages:
       name: petitparser
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.4.0"
+    version: "5.0.0"
   platform:
     dependency: transitive
     description:
@@ -365,13 +365,6 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.0"
-  quiver:
-    dependency: transitive
-    description:
-      name: quiver
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "3.0.1+1"
   shelf:
     dependency: transitive
     description:
@@ -488,7 +481,7 @@ packages:
       name: toml
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.0"
+    version: "0.13.1"
   typed_data:
     dependency: transitive
     description:
@@ -558,7 +551,7 @@ packages:
       name: xml
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.3.1"
+    version: "5.4.1"
   xml2json:
     dependency: transitive
     description:
@@ -574,5 +567,5 @@ packages:
     source: hosted
     version: "3.1.0"
 sdks:
-  dart: ">=2.17.0-0 <3.0.0"
+  dart: ">=2.17.0 <3.0.0"
   flutter: ">=2.5.0"

--- a/example/test/namespace_example_test.dart
+++ b/example/test/namespace_example_test.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_i18n_example/main.dart' as appmain;
 import 'package:flutter_test/flutter_test.dart';

--- a/lib/flutter_i18n.dart
+++ b/lib/flutter_i18n.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 
-import 'package:flutter/foundation.dart' as Foundation;
 import 'package:flutter/widgets.dart';
 import 'package:flutter_i18n/loaders/file_translation_loader.dart';
 import 'package:flutter_i18n/loaders/translation_loader.dart';
@@ -8,8 +7,6 @@ import 'package:flutter_i18n/models/loading_status.dart';
 import 'package:flutter_i18n/utils/plural_translator.dart';
 import 'package:flutter_i18n/utils/simple_translator.dart';
 import 'package:intl/intl.dart' as intl;
-
-import 'utils/message_printer.dart';
 
 export 'flutter_i18n_delegate.dart';
 export 'loaders/e2e_file_translation_loader.dart';

--- a/lib/flutter_i18n_delegate.dart
+++ b/lib/flutter_i18n_delegate.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 
 import 'package:flutter/material.dart';
-import 'package:flutter_i18n/loaders/translation_loader.dart';
 import 'package:flutter_i18n/utils/message_printer.dart';
 
 import 'flutter_i18n.dart';

--- a/lib/loaders/e2e_file_translation_loader.dart
+++ b/lib/loaders/e2e_file_translation_loader.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'dart:convert';
-import 'dart:typed_data';
 
 import 'package:flutter/services.dart';
 

--- a/lib/loaders/file_translation_loader.dart
+++ b/lib/loaders/file_translation_loader.dart
@@ -1,7 +1,6 @@
 import 'dart:async';
 
 import 'package:flutter/services.dart';
-import 'package:flutter/services.dart' show rootBundle;
 import 'package:flutter/widgets.dart';
 import 'package:flutter_i18n/loaders/decoders/base_decode_strategy.dart';
 import 'package:flutter_i18n/loaders/decoders/json_decode_strategy.dart';
@@ -87,8 +86,8 @@ class FileTranslationLoader extends TranslationLoader implements IFileContent {
       V mapResult;
       if (result.containsKey(key)) {
         if (p1 is Map && p2 is Map) {
-          Map map1 = p1 as Map;
-          Map map2 = p2 as Map;
+          Map map1 = p1;
+          Map map2 = p2;
           mapResult = _deepMergeMaps(map1, map2) as V;
         } else {
           mapResult = p2;

--- a/lib/loaders/namespace_file_translation_loader.dart
+++ b/lib/loaders/namespace_file_translation_loader.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/services.dart';
-import 'package:flutter/services.dart' show rootBundle;
 import 'package:flutter_i18n/loaders/file_translation_loader.dart';
 import 'package:flutter_i18n/utils/message_printer.dart';
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -146,14 +146,7 @@ packages:
       name: petitparser
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "4.4.0"
-  quiver:
-    dependency: transitive
-    description:
-      name: quiver
-      url: "https://pub.dartlang.org"
-    source: hosted
-    version: "3.1.0"
+    version: "5.0.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -207,7 +200,7 @@ packages:
       name: toml
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.12.0"
+    version: "0.13.1"
   typed_data:
     dependency: transitive
     description:
@@ -228,14 +221,14 @@ packages:
       name: xml
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.3.1"
+    version: "6.1.0"
   xml2json:
     dependency: "direct main"
     description:
       name: xml2json
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.3.2"
+    version: "5.3.3"
   yaml:
     dependency: "direct main"
     description:
@@ -244,4 +237,4 @@ packages:
     source: hosted
     version: "3.1.1"
 sdks:
-  dart: ">=2.17.0-0 <3.0.0"
+  dart: ">=2.17.0 <3.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: flutter_i18n
 description: i18n made easy for Flutter. With flutter_i18n you can make your app international, using just a simple .json file!
-version: 0.32.3
+version: 0.32.4
 homepage: https://github.com/ilteoood/flutter_i18n
 issue_tracker: https://github.com/ilteoood/flutter_i18n/issues
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -15,7 +15,7 @@ dependencies:
   yaml: ^3.1.0
   xml2json: ^5.3.2
   path: ^1.8.0
-  toml: ^0.12.0
+  toml: ^0.13.1
   logging: ^1.0.2
   http: ^0.13.4
 

--- a/test/loaders/file_translation_loader_test.dart
+++ b/test/loaders/file_translation_loader_test.dart
@@ -1,5 +1,3 @@
-import 'dart:math';
-
 import 'package:flutter/material.dart';
 import 'package:flutter_i18n/flutter_i18n.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/test/loaders/network_file_translation_loader_test.dart
+++ b/test/loaders/network_file_translation_loader_test.dart
@@ -1,8 +1,6 @@
 import 'package:flutter_i18n/flutter_i18n.dart';
 import 'package:flutter_test/flutter_test.dart';
 
-import '../test_asset_bundle.dart';
-
 class CustomNetworkFileTranslationLoader extends NetworkFileTranslationLoader {
   CustomNetworkFileTranslationLoader({required baseUri})
       : super(baseUri: baseUri);


### PR DESCRIPTION
Hi @ilteoood!

We use `flutter_i18n` for our project and it is currently preventing upgrading another package because of not supporting `toml ^0.13.1`.

I ran `flutter pub upgrade --major-versions` to update the dependencies. After that I incremented the version with one patch value. As bonus I ran `flutter analyze` and removed all the unnecessary imports and casts.

If you have any suggestions, please feel free to leave them here in the comments 😄 