### PR TITLE
[Feature] Unused action

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,15 +12,22 @@ I18n made easy, for Flutter!
 
 ## Table of contents
 
-* [Why should you use flutter_i18n?](#why-should-you-use-flutter_i18n)
-* [Loaders](#loaders)
-  * [FileTranslationLoader](#filetranslationloader-configuration)
-  * [NetworkFileTranslationLoader](#networkfiletranslationloader-configuration)
-  * [NamespaceFileTranslationLoader](#namespacefiletranslationloader-configuration)
-  * [E2EFileTranslationLoader](#e2efiletranslationloader-configuration)
-* [flutter_i18n in action](#flutter_i18n-in-action)
-* [Plugins](#plugins)
-* [Contributors](#contributors-)
+- [flutter\_i18n](#flutter_i18n)
+  - [Table of contents](#table-of-contents)
+  - [Why should you use flutter\_i18n?](#why-should-you-use-flutter_i18n)
+  - [Loaders](#loaders)
+    - [`FileTranslationLoader` configuration](#filetranslationloader-configuration)
+    - [`NetworkFileTranslationLoader` configuration](#networkfiletranslationloader-configuration)
+    - [`NamespaceFileTranslationLoader` configuration](#namespacefiletranslationloader-configuration)
+    - [`E2EFileTranslationLoader` configuration](#e2efiletranslationloader-configuration)
+  - [flutter\_i18n in action](#flutter_i18n-in-action)
+  - [Utilities](#utilities)
+    - [Commands](#commands)
+      - [Validate](#validate)
+      - [Diff](#diff)
+      - [Unused](#unused)
+  - [Plugins](#plugins)
+  - [Contributors ✨](#contributors-)
 
 ## Why should you use flutter_i18n?
 
@@ -284,6 +291,40 @@ This command is used to find the differences between the keys of the desired tra
 [flutter_i18n INFO]: YAML file loaded for en
 [flutter_i18n INFO]: JSON file loaded for it
 [flutter_i18n ERROR]: The compared dictionary doesn't contain the key >title
+```
+
+#### Unused
+
+This command is used to find out the unused translation assets in your project.
+
+Some flag for the command:
+- `--md`: to generate Markdown report file.
+- `--path=<path>`: to determine where the report file is stored (default is `unused_translations.md`).
+- `--scan=<file/dir>`: to determine the files scanned (default is `/lib` and `/test`).
+
+```sh
+> flutter pub run flutter_i18n unused
+=== Unused translation keys ===
+Defined in translation files but never referenced in source code
+Total: 0
+
+  None
+
+=== Missing translation keys ===
+Referenced in source code but not found in translation files
+Total: 5
+
+  - args.content
+  - args.title
+  - button.label.clickMea
+  - home.missing
+  - type
+
+=== Dynamic keys ===
+Keys constructed with variables or expressions — cannot analyze statically
+Total: 0
+
+  None
 ```
 
 ## Plugins

--- a/bin/actions/action_interface.dart
+++ b/bin/actions/action_interface.dart
@@ -20,15 +20,20 @@ abstract class AbstractAction {
   }
 
   Future<List<FileSystemEntity>> retrieveAssetsContent() async {
-    final List<String> assetsFolder = await retrieveAssetsFolders();
-    return assetsFolder
-        .map((folder) => Directory(folder))
-        .where(existFolder)
-        .map(folderContent)
-        .where((folderContent) => folderContent.isNotEmpty)
-        .fold(<FileSystemEntity>[], listFold)
-        .where(filterExtension)
-        .toList();
+    final List<String> assetEntries = await retrieveAssetsFolders();
+    final results = <FileSystemEntity>[];
+    for (final entry in assetEntries) {
+      final dir = Directory(entry);
+      if (dir.existsSync()) {
+        results.addAll(dir.listSync().where(filterExtension));
+        continue;
+      }
+      final file = File(entry);
+      if (file.existsSync() && filterExtension(file)) {
+        results.add(file);
+      }
+    }
+    return results;
   }
 
   bool existFolder(final Directory directory) {

--- a/bin/actions/action_interface.dart
+++ b/bin/actions/action_interface.dart
@@ -4,7 +4,7 @@ import 'package:path/path.dart';
 import 'package:yaml/yaml.dart';
 
 abstract class AbstractAction {
-  List<String> get acceptedExtensions => ['.json', '.yaml', '.xml'];
+  Set<String> get acceptedExtensions => {'.json', '.yaml', '.xml'};
 
   void executeAction(final List<String> params);
 
@@ -34,20 +34,6 @@ abstract class AbstractAction {
       }
     }
     return results;
-  }
-
-  bool existFolder(final Directory directory) {
-    return directory.existsSync();
-  }
-
-  List<FileSystemEntity> folderContent(final Directory directory) {
-    return directory.listSync();
-  }
-
-  List<FileSystemEntity> listFold(final List<FileSystemEntity> previousValue,
-      final List<FileSystemEntity> currentValue) {
-    previousValue.addAll(currentValue);
-    return previousValue;
   }
 
   bool filterExtension(final FileSystemEntity fileSystemEntity) {

--- a/bin/actions/unused_action.dart
+++ b/bin/actions/unused_action.dart
@@ -237,8 +237,10 @@ class UnusedAction extends AbstractAction {
     if (keys.isEmpty) {
       MessagePrinter.info('  None');
     } else {
+      var n = 1;
       for (final key in keys) {
-        MessagePrinter.info('  - $key');
+        MessagePrinter.info('  $n. $key');
+        n++;
       }
     }
   }
@@ -253,9 +255,14 @@ class UnusedAction extends AbstractAction {
     if (refs.isEmpty) {
       MessagePrinter.info('  None');
     } else {
+      var n = 1;
       for (final ref in refs) {
-        MessagePrinter.info(
-            '  ${ref.filePath}:${ref.line}  →  ${ref.lineContent}');
+        final rel = p.relative(ref.filePath, from: Directory.current.path);
+        MessagePrinter.info('  $n. $rel:${ref.line}');
+        for (final line in ref.lineContent.split('\n')) {
+          MessagePrinter.info('    $line');
+        }
+        n++;
       }
     }
     MessagePrinter.info('');
@@ -271,8 +278,10 @@ class UnusedAction extends AbstractAction {
     if (keys.isEmpty) {
       buf.writeln('*None*');
     } else {
+      var n = 1;
       for (final key in keys) {
-        buf.writeln('- `$key`');
+        buf.writeln('$n. `$key`');
+        n++;
       }
     }
     buf.writeln();
@@ -288,12 +297,18 @@ class UnusedAction extends AbstractAction {
     if (refs.isEmpty) {
       buf.writeln('*None*');
     } else {
-      buf.writeln('| File | Content |');
-      buf.writeln('|------|---------|');
+      var n = 1;
       for (final ref in refs) {
         final rel = p.relative(ref.filePath, from: Directory.current.path);
-        buf.writeln(
-            '| [$rel:${ref.line}]($rel#L${ref.line}) | `${ref.lineContent}` |');
+        buf.writeln('$n. **[$rel:${ref.line}]($rel#L${ref.line})**');
+        buf.writeln();
+        buf.writeln('  ```dart');
+        for (final line in ref.lineContent.split('\n')) {
+          buf.writeln('  $line');
+        }
+        buf.writeln('  ```');
+        buf.writeln();
+        n++;
       }
     }
     buf.writeln();

--- a/bin/actions/unused_action.dart
+++ b/bin/actions/unused_action.dart
@@ -58,7 +58,8 @@ class UnusedAction extends AbstractAction {
       } else if (param.startsWith('--path=')) {
         final v = param.substring('--path='.length);
         if (v.isEmpty) {
-          MessagePrinter.error('--path requires a value (e.g. --path=report.md)');
+          MessagePrinter.error(
+              '--path requires a value (e.g. --path=report.md)');
         } else {
           _mdPath = v;
         }
@@ -100,8 +101,8 @@ class UnusedAction extends AbstractAction {
       if (dir.existsSync()) {
         // Skip folders already covered by a namespace basePath.
         final norm = p.normalize(folder);
-        if (nsBasePaths.any((bp) =>
-            norm == bp || norm.startsWith('$bp${p.separator}'))) {
+        if (nsBasePaths
+            .any((bp) => norm == bp || norm.startsWith('$bp${p.separator}'))) {
           continue;
         }
 

--- a/bin/actions/unused_action.dart
+++ b/bin/actions/unused_action.dart
@@ -97,29 +97,38 @@ class UnusedAction extends AbstractAction {
     final assetFolders = await retrieveAssetsFolders();
     for (final folder in assetFolders) {
       final dir = Directory(folder);
-      if (!dir.existsSync()) continue;
+      if (dir.existsSync()) {
+        // Skip folders already covered by a namespace basePath.
+        final norm = p.normalize(folder);
+        if (nsBasePaths.any((bp) =>
+            norm == bp || norm.startsWith('$bp${p.separator}'))) {
+          continue;
+        }
 
-      // Skip folders already covered by a namespace basePath.
-      final norm = p.normalize(folder);
-      if (nsBasePaths.any((bp) =>
-          norm == bp || norm.startsWith('$bp${p.separator}'))) {
+        final children = dir.listSync();
+        if (children.any((c) => c is Directory)) {
+          // Namespace A: folder contains locale-code subdirectories.
+          for (final child in children) {
+            if (child is Directory) {
+              await _addNamespaceDir(child, keys);
+            }
+          }
+        } else if (namespaceConfigs.isEmpty &&
+            _isNamespaceLocaleDir(folder, assetFolders)) {
+          // Namespace B: locale dir listed individually, no config found.
+          await _addNamespaceDir(dir, keys);
+        } else {
+          await _addFlatDir(dir, keys);
+        }
         continue;
       }
 
-      final children = dir.listSync();
-      if (children.any((c) => c is Directory)) {
-        // Namespace A: folder contains locale-code subdirectories.
-        for (final child in children) {
-          if (child is Directory) {
-            await _addNamespaceDir(child, keys);
-          }
-        }
-      } else if (namespaceConfigs.isEmpty &&
-          _isNamespaceLocaleDir(folder, assetFolders)) {
-        // Namespace B: locale dir listed individually, no config found.
-        await _addNamespaceDir(dir, keys);
-      } else {
-        await _addFlatDir(dir, keys);
+      // Individual files listed directly in assets.
+      final file = File(folder);
+      if (file.existsSync() &&
+          acceptedExtensions.contains(p.extension(folder))) {
+        final map = await LocalLoader(file).loadContent();
+        if (map != null) keys.addAll(KeyExtractor.extract(map));
       }
     }
 

--- a/bin/actions/unused_action.dart
+++ b/bin/actions/unused_action.dart
@@ -288,10 +288,12 @@ class UnusedAction extends AbstractAction {
     if (refs.isEmpty) {
       buf.writeln('*None*');
     } else {
-      buf.writeln('| File | Line | Content |');
-      buf.writeln('|------|------|---------|');
+      buf.writeln('| File | Content |');
+      buf.writeln('|------|---------|');
       for (final ref in refs) {
-        buf.writeln('| ${ref.filePath} | ${ref.line} | `${ref.lineContent}` |');
+        final rel = p.relative(ref.filePath, from: Directory.current.path);
+        buf.writeln(
+            '| [$rel:${ref.line}]($rel#L${ref.line}) | `${ref.lineContent}` |');
       }
     }
     buf.writeln();

--- a/bin/actions/unused_action.dart
+++ b/bin/actions/unused_action.dart
@@ -1,0 +1,290 @@
+import 'dart:io';
+
+import 'package:flutter_i18n/utils/message_printer.dart';
+import 'package:path/path.dart' as p;
+
+import '../utils/key_extractor.dart';
+import '../utils/local_loader.dart';
+import '../utils/source_scanner.dart';
+import 'action_interface.dart';
+
+class UnusedAction extends AbstractAction {
+  bool _md = false;
+  String _mdPath = 'unused_translations.md';
+  List<String> _scanPaths = [];
+
+  @override
+  List<String> get acceptedExtensions => ['.json', '.yaml', '.xml', '.toml'];
+
+  @override
+  void executeAction(final List<String> params) async {
+    _parseArgs(params);
+
+    final scanResult = SourceScanner.scan(
+      Directory.current.path,
+      scanPaths: _scanPaths.isNotEmpty ? _scanPaths : null,
+    );
+
+    final assetKeys = await _collectAssetKeys(scanResult.namespaceConfigs);
+
+    // Build matchable set and compute unused keys in a single pass.
+    final matchableAssets = <String>{...assetKeys};
+    final unused = <String>{};
+    for (final key in assetKeys) {
+      final norm = KeyExtractor.normalizePlural(key);
+      if (norm != null) matchableAssets.add(norm);
+
+      if (!scanResult.literalKeys.contains(key) &&
+          (norm == null || !scanResult.literalKeys.contains(norm))) {
+        unused.add(key);
+      }
+    }
+
+    // Missing: source keys not found in any translation file.
+    final missing = <String>{};
+    for (final key in scanResult.literalKeys) {
+      if (!matchableAssets.contains(key)) {
+        missing.add(key);
+      }
+    }
+
+    _report(unused, missing, scanResult.dynamicRefs);
+  }
+
+  void _parseArgs(List<String> params) {
+    for (final param in params) {
+      if (param == '--md') {
+        _md = true;
+      } else if (param.startsWith('--path=')) {
+        final v = param.substring('--path='.length);
+        if (v.isEmpty) {
+          MessagePrinter.error('--path requires a value (e.g. --path=report.md)');
+        } else {
+          _mdPath = v;
+        }
+      } else if (param.startsWith('--scan=')) {
+        _scanPaths = param
+            .substring('--scan='.length)
+            .split(',')
+            .map((s) => s.trim())
+            .where((s) => s.isNotEmpty)
+            .toList();
+      }
+    }
+  }
+
+  /// Walk every asset folder declared in pubspec and extract translation keys.
+  ///
+  /// If [namespaceConfigs] (extracted from source code) is non-empty, uses
+  /// the declared namespaces and basePath directly.  Falls back to
+  /// directory-structure heuristics otherwise.
+  Future<Set<String>> _collectAssetKeys(
+      List<NamespaceConfig> namespaceConfigs) async {
+    final keys = <String>{};
+
+    // Use explicit namespace config from source code.
+    for (final config in namespaceConfigs) {
+      if (config.isNamespace && config.basePath != null) {
+        await _loadFromNamespaceConfig(config, keys);
+      }
+    }
+
+    final nsBasePaths = namespaceConfigs
+        .where((c) => c.basePath != null)
+        .map((c) => p.normalize(c.basePath!))
+        .toSet();
+
+    final assetFolders = await retrieveAssetsFolders();
+    for (final folder in assetFolders) {
+      final dir = Directory(folder);
+      if (!dir.existsSync()) continue;
+
+      // Skip folders already covered by a namespace basePath.
+      final norm = p.normalize(folder);
+      if (nsBasePaths.any((bp) =>
+          norm == bp || norm.startsWith('$bp${p.separator}'))) {
+        continue;
+      }
+
+      final children = dir.listSync();
+      if (children.any((c) => c is Directory)) {
+        // Namespace A: folder contains locale-code subdirectories.
+        for (final child in children) {
+          if (child is Directory) {
+            await _addNamespaceDir(child, keys);
+          }
+        }
+      } else if (namespaceConfigs.isEmpty &&
+          _isNamespaceLocaleDir(folder, assetFolders)) {
+        // Namespace B: locale dir listed individually, no config found.
+        await _addNamespaceDir(dir, keys);
+      } else {
+        await _addFlatDir(dir, keys);
+      }
+    }
+
+    return keys;
+  }
+
+  /// True when [folder] is one of multiple locale directories sharing a
+  /// common parent.
+  bool _isNamespaceLocaleDir(String folder, List<String> allFolders) {
+    final parent = p.dirname(folder);
+    return allFolders.where((f) => p.dirname(f) == parent).length > 1;
+  }
+
+  /// Load translation files using the explicit namespace config.
+  Future<void> _loadFromNamespaceConfig(
+      NamespaceConfig config, Set<String> keys) async {
+    final base = Directory(config.basePath!);
+    if (!base.existsSync()) return;
+
+    for (final localeDir in base.listSync()) {
+      if (localeDir is! Directory) continue;
+      for (final namespace in config.namespaces) {
+        for (final entity in localeDir.listSync()) {
+          if (entity is! File) continue;
+          if (p.basenameWithoutExtension(p.basename(entity.path)) !=
+              namespace) {
+            continue;
+          }
+          if (!acceptedExtensions.contains(p.extension(entity.path))) {
+            continue;
+          }
+
+          final map = await LocalLoader(entity).loadContent();
+          if (map == null) continue;
+          for (final key in KeyExtractor.extract(map)) {
+            keys.add('$namespace.$key');
+          }
+        }
+      }
+    }
+  }
+
+  Future<void> _addNamespaceDir(Directory dir, Set<String> keys) async {
+    for (final entity in dir.listSync()) {
+      if (entity is File &&
+          acceptedExtensions.contains(p.extension(entity.path))) {
+        final map = await LocalLoader(entity).loadContent();
+        if (map == null) continue;
+        final ns = p.basenameWithoutExtension(p.basename(entity.path));
+        for (final key in KeyExtractor.extract(map)) {
+          keys.add('$ns.$key');
+        }
+      }
+    }
+  }
+
+  Future<void> _addFlatDir(Directory dir, Set<String> keys) async {
+    for (final entity in dir.listSync()) {
+      if (entity is File &&
+          acceptedExtensions.contains(p.extension(entity.path))) {
+        final map = await LocalLoader(entity).loadContent();
+        if (map == null) continue;
+        keys.addAll(KeyExtractor.extract(map));
+      }
+    }
+  }
+
+  void _report(
+    Set<String> unused,
+    Set<String> missing,
+    List<DynamicKeyRef> dynamicRefs,
+  ) {
+    final sortedUnused = unused.toList()..sort();
+    final sortedMissing = missing.toList()..sort();
+
+    if (!_md) {
+      // Terminal output.
+      _printSection('Unused translation keys', sortedUnused,
+          'Defined in translation files but never referenced in source code');
+      _printSection('Missing translation keys', sortedMissing,
+          'Referenced in source code but not found in translation files');
+      _printDynamicSection(dynamicRefs);
+    } else {
+      // Markdown file output.
+      final buf = StringBuffer();
+      buf.writeln('# Unused Translation Report');
+      buf.writeln();
+
+      _writeMdSection(buf, 'Unused translation keys', sortedUnused,
+          'Defined in translation files but never referenced in source code');
+      _writeMdSection(buf, 'Missing translation keys', sortedMissing,
+          'Referenced in source code but not found in translation files');
+      _writeMdDynamicSection(buf, dynamicRefs);
+
+      File(_mdPath).writeAsStringSync(buf.toString());
+      MessagePrinter.info('Report written to $_mdPath');
+    }
+  }
+
+  void _printSection(String title, List<String> keys, String description) {
+    MessagePrinter.info('');
+    MessagePrinter.info('=== $title ===');
+    MessagePrinter.info(description);
+    MessagePrinter.info('Total: ${keys.length}');
+    MessagePrinter.info('');
+    if (keys.isEmpty) {
+      MessagePrinter.info('  None');
+    } else {
+      for (final key in keys) {
+        MessagePrinter.info('  - $key');
+      }
+    }
+  }
+
+  void _printDynamicSection(List<DynamicKeyRef> refs) {
+    MessagePrinter.info('');
+    MessagePrinter.info('=== Dynamic keys ===');
+    MessagePrinter.info(
+        'Keys constructed with variables or expressions — cannot analyze statically');
+    MessagePrinter.info('Total: ${refs.length}');
+    MessagePrinter.info('');
+    if (refs.isEmpty) {
+      MessagePrinter.info('  None');
+    } else {
+      for (final ref in refs) {
+        MessagePrinter.info(
+            '  ${ref.filePath}:${ref.line}  →  ${ref.lineContent}');
+      }
+    }
+    MessagePrinter.info('');
+  }
+
+  void _writeMdSection(
+      StringBuffer buf, String title, List<String> keys, String description) {
+    buf.writeln('## $title');
+    buf.writeln();
+    buf.writeln('$description  ');
+    buf.writeln('**Total: ${keys.length}**  ');
+    buf.writeln();
+    if (keys.isEmpty) {
+      buf.writeln('*None*');
+    } else {
+      for (final key in keys) {
+        buf.writeln('- `$key`');
+      }
+    }
+    buf.writeln();
+  }
+
+  void _writeMdDynamicSection(StringBuffer buf, List<DynamicKeyRef> refs) {
+    buf.writeln('## Dynamic keys (manual review needed)');
+    buf.writeln();
+    buf.writeln(
+        'Keys constructed with variables or expressions — cannot analyze statically.  ');
+    buf.writeln('**Total: ${refs.length}**  ');
+    buf.writeln();
+    if (refs.isEmpty) {
+      buf.writeln('*None*');
+    } else {
+      buf.writeln('| File | Line | Content |');
+      buf.writeln('|------|------|---------|');
+      for (final ref in refs) {
+        buf.writeln('| ${ref.filePath} | ${ref.line} | `${ref.lineContent}` |');
+      }
+    }
+    buf.writeln();
+  }
+}

--- a/bin/actions/unused_action.dart
+++ b/bin/actions/unused_action.dart
@@ -14,7 +14,7 @@ class UnusedAction extends AbstractAction {
   List<String> _scanPaths = [];
 
   @override
-  List<String> get acceptedExtensions => ['.json', '.yaml', '.xml', '.toml'];
+  Set<String> get acceptedExtensions => {'.json', '.yaml', '.xml', '.toml'};
 
   @override
   void executeAction(final List<String> params) async {

--- a/bin/flutter_i18n.dart
+++ b/bin/flutter_i18n.dart
@@ -1,5 +1,6 @@
 import 'actions/action_interface.dart';
 import 'actions/diff_action.dart';
+import 'actions/unused_action.dart';
 import 'actions/validate_action.dart';
 
 void main(final List<String> args) async {
@@ -20,6 +21,8 @@ AbstractAction retrieveAction(final String action) {
       return ValidateAction();
     case 'diff':
       return DiffAction();
+    case 'unused':
+      return UnusedAction();
     default:
       throw Exception("Unrecognized arg: $action");
   }

--- a/bin/utils/key_extractor.dart
+++ b/bin/utils/key_extractor.dart
@@ -1,0 +1,50 @@
+/// Flattens a nested [map] into a set of dotted key paths.
+///
+/// Leaf keys whose value is a scalar (String, int, double, num, bool) are
+/// included.  Collection types (List, Set, Map) are skipped — Maps are
+/// recursed into for their children; Lists and Sets are treated as
+/// non-translatable structural data.
+class KeyExtractor {
+  /// Extract all scalar-leaf keys from [map] as dotted paths.
+  static Set<String> extract(Map<dynamic, dynamic> map) {
+    final keys = <String>{};
+    _walk(map, [], keys);
+    return keys;
+  }
+
+  static void _walk(
+    Map<dynamic, dynamic> map,
+    List<String> path,
+    Set<String> result,
+  ) {
+    for (final entry in map.entries) {
+      final key = entry.key.toString();
+      final value = entry.value;
+      path.add(key);
+      if (value is Map) {
+        _walk(value, path, result);
+      } else if (_isScalar(value)) {
+        result.add(path.join('.'));
+      }
+      path.removeLast();
+    }
+  }
+
+  static bool _isScalar(dynamic value) {
+    return value is String || value is num || value is bool;
+  }
+
+  /// Returns the key with its trailing plural suffix stripped.
+  /// Example: `"clicked.times-2"` → `"clicked.times"`.
+  /// Returns null if the key does not have a plural suffix, or if the numeric
+  /// suffix exceeds [maxSuffix] (default 99) — large numbers like `-404` are
+  /// unlikely to be plural forms.
+  static String? normalizePlural(String key, {int maxSuffix = 99}) {
+    final idx = key.lastIndexOf('-');
+    if (idx < 0) return null;
+    final suffix = key.substring(idx + 1);
+    final n = int.tryParse(suffix);
+    if (n == null || n > maxSuffix) return null;
+    return key.substring(0, idx);
+  }
+}

--- a/bin/utils/source_scanner.dart
+++ b/bin/utils/source_scanner.dart
@@ -256,8 +256,7 @@ class SourceScanner {
 
   /// Scans [file] for NamespaceFileTranslationLoader constructors and
   /// extracts namespace configuration.
-  static void _scanNamespaceConfigs(
-      File file, List<NamespaceConfig> results) {
+  static void _scanNamespaceConfigs(File file, List<NamespaceConfig> results) {
     final content = file.readAsStringSync();
 
     for (final match in _nsLoaderRe.allMatches(content)) {
@@ -311,8 +310,7 @@ class SourceScanner {
   /// Parses `"common", "home"` or `'common', 'home'` into a list of strings.
   static List<String> _parseStringList(String input) {
     final result = <String>[];
-    for (final match
-        in RegExp(r"""['"]([^'"]*)['"]""").allMatches(input)) {
+    for (final match in RegExp(r"""['"]([^'"]*)['"]""").allMatches(input)) {
       result.add(match.group(1)!);
     }
     return result;

--- a/bin/utils/source_scanner.dart
+++ b/bin/utils/source_scanner.dart
@@ -162,8 +162,8 @@ class SourceScanner {
         if (!s.contains(r'$')) literalKeys.add(s);
       }
       final lineNum = _offsetToLine(strippedLines, match.start);
-      dynamicRefs
-          .add(DynamicKeyRef(file.path, lineNum, lines[lineNum - 1].trim()));
+      final fullCall = stripped.substring(match.start, closeParen + 1);
+      dynamicRefs.add(DynamicKeyRef(file.path, lineNum, fullCall));
     }
   }
 

--- a/bin/utils/source_scanner.dart
+++ b/bin/utils/source_scanner.dart
@@ -1,0 +1,263 @@
+import 'dart:io';
+
+import 'package:path/path.dart' as p;
+
+/// A reference to a translation key found in source code.
+class DynamicKeyRef {
+  final String filePath;
+  final int line;
+  final String lineContent;
+
+  const DynamicKeyRef(this.filePath, this.line, this.lineContent);
+}
+
+/// Configuration extracted from a NamespaceFileTranslationLoader constructor
+/// in source code.
+class NamespaceConfig {
+  final String? basePath;
+  final List<String> namespaces;
+
+  const NamespaceConfig({this.basePath, this.namespaces = const []});
+
+  bool get isNamespace => namespaces.isNotEmpty;
+}
+
+/// Result of scanning source files for translation key usages.
+class SourceScanResult {
+  final Set<String> literalKeys;
+  final List<DynamicKeyRef> dynamicRefs;
+  final List<NamespaceConfig> namespaceConfigs;
+
+  const SourceScanResult(
+    this.literalKeys,
+    this.dynamicRefs, {
+    this.namespaceConfigs = const [],
+  });
+}
+
+/// Scans Dart source files for FlutterI18n key usages using regex.
+///
+/// Recognizes four call patterns (with optional import-alias prefix):
+/// - `FlutterI18n.translate(context, "key")`
+/// - `FlutterI18n.plural(context, "key", n)`
+/// - `I18nText("key")`
+/// - `I18nPlural("key", n)`
+///
+/// Also captures keys from `fallbackKey:` named parameters.
+class SourceScanner {
+  // Matches FlutterI18n.translate/plural where key is the 2nd positional arg.
+  // \b ensures we don't match MyFlutterI18n or FlutterI18nFoo.
+  static final _fluentKeyRe = RegExp(
+    r"""(?:\w+\.)?\bFlutterI18n\s*\.\s*(?:translate|plural)\s*\([^,]+,\s*["']([^"']*)["']""",
+  );
+
+  // Matches I18nText/I18nPlural constructors where key is the 1st arg.
+  static final _widgetKeyRe = RegExp(
+    r"""(?:\w+\.)?\bI18n(?:Text|Plural)\s*\(\s*["']([^"']*)["']""",
+  );
+
+  // Matches fallbackKey: "..." or fallbackKey: '...'
+  static final _fallbackKeyRe = RegExp(
+    r"""fallbackKey\s*:\s*["']([^"']*)["']""",
+  );
+
+  // Matches any FlutterI18n.translate/plural or I18nText/I18nPlural call
+  // line (used to detect dynamic usages that weren't caught by the
+  // literal-key regexes above).
+  static final _dynamicCallRe = RegExp(
+    r"""(?:\w+\.)?\b(?:FlutterI18n\s*\.\s*(?:translate|plural)|I18n(?:Text|Plural))\s*\(""",
+  );
+
+  /// Scans all `.dart` files under [projectRoot] and returns extracted keys
+  /// plus any dynamic references.
+  ///
+  /// If [scanPaths] is provided, only those files/directories are scanned
+  /// (relative to [projectRoot] unless absolute). Defaults to `lib/` and
+  /// `test/` directories.
+  static SourceScanResult scan(String projectRoot, {List<String>? scanPaths}) {
+    final literalKeys = <String>{};
+    final dynamicRefs = <DynamicKeyRef>[];
+    final namespaceConfigs = <NamespaceConfig>[];
+
+    final dartFiles = _findDartFiles(projectRoot, scanPaths: scanPaths);
+    for (final file in dartFiles) {
+      _scanFile(file, literalKeys, dynamicRefs);
+      _scanNamespaceConfigs(file, namespaceConfigs);
+    }
+
+    return SourceScanResult(literalKeys, dynamicRefs,
+        namespaceConfigs: namespaceConfigs);
+  }
+
+  static List<File> _findDartFiles(String root, {List<String>? scanPaths}) {
+    final rootDir = Directory(root);
+    if (!rootDir.existsSync()) return [];
+
+    final targetPaths = (scanPaths != null && scanPaths.isNotEmpty)
+        ? scanPaths
+        : ['lib', 'test'];
+
+    final files = <File>[];
+    for (final scanPath in targetPaths) {
+      final fullPath =
+          p.isAbsolute(scanPath) ? scanPath : p.join(root, scanPath);
+      final type = FileSystemEntity.typeSync(fullPath, followLinks: false);
+      if (type == FileSystemEntityType.file && fullPath.endsWith('.dart')) {
+        files.add(File(fullPath));
+      } else if (type == FileSystemEntityType.directory) {
+        _collectDartFiles(Directory(fullPath), files);
+      }
+    }
+
+    return files;
+  }
+
+  static void _collectDartFiles(Directory dir, List<File> files) {
+    for (final entity in dir.listSync(recursive: true)) {
+      if (entity is File && entity.path.endsWith('.dart')) {
+        files.add(entity);
+      }
+    }
+  }
+
+  static void _scanFile(
+    File file,
+    Set<String> literalKeys,
+    List<DynamicKeyRef> dynamicRefs,
+  ) {
+    final lines = file.readAsLinesSync();
+    final strippedLines = lines.map((line) {
+      final idx = _findCommentIndex(line);
+      return idx >= 0 ? line.substring(0, idx) : line;
+    }).toList();
+    final stripped = strippedLines.join('\n');
+
+    // fallbackKey references can appear anywhere in a call.
+    for (final match in _fallbackKeyRe.allMatches(stripped)) {
+      final key = match.group(1)!;
+      if (!key.contains(r'$')) literalKeys.add(key);
+    }
+
+    // Classify each FlutterI18n / I18nText / I18nPlural call site.
+    for (final match in _dynamicCallRe.allMatches(stripped)) {
+      // match.end points right after the opening '('.
+      final openParen = match.end - 1;
+      final closeParen = _findMatchingParen(stripped, openParen);
+      if (closeParen == -1) continue;
+
+      final region = stripped.substring(match.start, closeParen + 1);
+      final keyMatch =
+          _fluentKeyRe.firstMatch(region) ?? _widgetKeyRe.firstMatch(region);
+
+      if (keyMatch != null && !keyMatch.group(1)!.contains(r'$')) {
+        literalKeys.add(keyMatch.group(1)!);
+      } else {
+        final lineNum = _offsetToLine(strippedLines, match.start);
+        dynamicRefs
+            .add(DynamicKeyRef(file.path, lineNum, lines[lineNum - 1].trim()));
+      }
+    }
+  }
+
+  /// Converts a character offset in joined [lines] (separated by '\n') to a
+  /// 1-based line number.
+  static int _offsetToLine(List<String> lines, int offset) {
+    var current = 0;
+    for (var i = 0; i < lines.length; i++) {
+      current += lines[i].length + 1; // +1 for '\n'
+      if (current > offset) return i + 1;
+    }
+    return lines.length;
+  }
+
+  /// Returns the index of the first `//` that is _not_ inside a string literal,
+  /// or -1 if there is no comment on this line.
+  ///
+  /// Handles both single- and double-quoted strings. Does not handle
+  /// multi-line strings or escaped quotes inside strings.
+  static int _findCommentIndex(String line) {
+    var inSingle = false;
+    var inDouble = false;
+
+    for (var i = 0; i < line.length - 1; i++) {
+      final ch = line[i];
+      if (ch == "'" && !inDouble) {
+        inSingle = !inSingle;
+      } else if (ch == '"' && !inSingle) {
+        inDouble = !inDouble;
+      } else if (ch == '/' && !inSingle && !inDouble) {
+        if (line[i + 1] == '/') return i;
+      }
+    }
+    return -1;
+  }
+
+  // Matches NamespaceFileTranslationLoader constructor with optional alias.
+  static final _nsLoaderRe = RegExp(
+    r'(?:\w+\.)?\bNamespaceFileTranslationLoader\s*\(',
+  );
+
+  /// Scans [file] for NamespaceFileTranslationLoader constructors and
+  /// extracts namespace configuration.
+  static void _scanNamespaceConfigs(
+      File file, List<NamespaceConfig> results) {
+    final content = file.readAsStringSync();
+
+    for (final match in _nsLoaderRe.allMatches(content)) {
+      final closeParen = _findMatchingParen(content, match.end - 1);
+      if (closeParen == -1) continue;
+
+      final region = content.substring(match.start, closeParen + 1);
+
+      final nsMatch =
+          RegExp(r'''namespaces\s*:\s*\[([^\]]*)\]''').firstMatch(region);
+      if (nsMatch == null) continue;
+
+      final namespaces = _parseStringList(nsMatch.group(1)!);
+      if (namespaces.isEmpty) continue;
+
+      final bpMatch =
+          RegExp(r'''basePath\s*:\s*['"]([^'"]*)['"]''').firstMatch(region);
+      final basePath = bpMatch?.group(1);
+
+      results.add(NamespaceConfig(
+        basePath: basePath,
+        namespaces: namespaces,
+      ));
+    }
+  }
+
+  /// Finds the matching `)` for the opening paren at [openPos], accounting
+  /// for string literals.
+  static int _findMatchingParen(String content, int openPos) {
+    var depth = 0;
+    var inSingle = false;
+    var inDouble = false;
+
+    for (var i = openPos; i < content.length; i++) {
+      final ch = content[i];
+      if (ch == "'" && !inDouble) {
+        inSingle = !inSingle;
+      } else if (ch == '"' && !inSingle) {
+        inDouble = !inDouble;
+      } else if (!inSingle && !inDouble) {
+        if (ch == '(') depth++;
+        if (ch == ')') {
+          depth--;
+          if (depth == 0) return i;
+        }
+      }
+    }
+    return -1;
+  }
+
+  /// Parses `"common", "home"` or `'common', 'home'` into a list of strings.
+  static List<String> _parseStringList(String input) {
+    final result = <String>[];
+    for (final match
+        in RegExp(r"""['"]([^'"]*)['"]""").allMatches(input)) {
+      result.add(match.group(1)!);
+    }
+    return result;
+  }
+}

--- a/bin/utils/source_scanner.dart
+++ b/bin/utils/source_scanner.dart
@@ -45,28 +45,20 @@ class SourceScanResult {
 ///
 /// Also captures keys from `fallbackKey:` named parameters.
 class SourceScanner {
-  // Matches FlutterI18n.translate/plural where key is the 2nd positional arg.
-  // \b ensures we don't match MyFlutterI18n or FlutterI18nFoo.
-  static final _fluentKeyRe = RegExp(
-    r"""(?:\w+\.)?\bFlutterI18n\s*\.\s*(?:translate|plural)\s*\([^,]+,\s*["']([^"']*)["']""",
-  );
-
-  // Matches I18nText/I18nPlural constructors where key is the 1st arg.
-  static final _widgetKeyRe = RegExp(
-    r"""(?:\w+\.)?\bI18n(?:Text|Plural)\s*\(\s*["']([^"']*)["']""",
-  );
-
   // Matches fallbackKey: "..." or fallbackKey: '...'
   static final _fallbackKeyRe = RegExp(
     r"""fallbackKey\s*:\s*["']([^"']*)["']""",
   );
 
   // Matches any FlutterI18n.translate/plural or I18nText/I18nPlural call
-  // line (used to detect dynamic usages that weren't caught by the
-  // literal-key regexes above).
+  // site — the opening `(` is included so we can locate the argument list.
   static final _dynamicCallRe = RegExp(
     r"""(?:\w+\.)?\b(?:FlutterI18n\s*\.\s*(?:translate|plural)|I18n(?:Text|Plural))\s*\(""",
   );
+
+  // Extracts hardcoded string literals from call arguments — useful for
+  // ternary branches like `cond ? "key.a" : "key.b"`.
+  static final _stringLiteralRe = RegExp(r"""["']([^"']+)["']""");
 
   /// Scans all `.dart` files under [projectRoot] and returns extracted keys
   /// plus any dynamic references.
@@ -145,18 +137,83 @@ class SourceScanner {
       final closeParen = _findMatchingParen(stripped, openParen);
       if (closeParen == -1) continue;
 
-      final region = stripped.substring(match.start, closeParen + 1);
-      final keyMatch =
-          _fluentKeyRe.firstMatch(region) ?? _widgetKeyRe.firstMatch(region);
+      // Fluent API → key is 2nd positional arg (index 1).
+      // Widget constructors → key is 1st positional arg (index 0).
+      final isFluent = match.group(0)!.contains('FlutterI18n');
+      final argIndex = isFluent ? 1 : 0;
 
-      if (keyMatch != null && !keyMatch.group(1)!.contains(r'$')) {
-        literalKeys.add(keyMatch.group(1)!);
-      } else {
-        final lineNum = _offsetToLine(strippedLines, match.start);
-        dynamicRefs
-            .add(DynamicKeyRef(file.path, lineNum, lines[lineNum - 1].trim()));
+      final keyArg = _extractArg(stripped, match.end, argIndex);
+      if (keyArg == null) continue;
+
+      if (_isPureString(keyArg)) {
+        final inner = keyArg.trim();
+        final value = inner.substring(1, inner.length - 1);
+        if (!value.contains(r'$')) {
+          literalKeys.add(value);
+          continue;
+        }
+      }
+
+      // Key argument is not a plain string — extract any hardcoded string
+      // literals inside it (e.g. ternary branches) for the literal set,
+      // and also flag the call as dynamic.
+      for (final m in _stringLiteralRe.allMatches(keyArg)) {
+        final s = m.group(1)!;
+        if (!s.contains(r'$')) literalKeys.add(s);
+      }
+      final lineNum = _offsetToLine(strippedLines, match.start);
+      dynamicRefs
+          .add(DynamicKeyRef(file.path, lineNum, lines[lineNum - 1].trim()));
+    }
+  }
+
+  /// True when [arg] is a single string literal (possibly surrounded by
+  /// whitespace), e.g. `"home.title"` or `  'settings.general'  `.
+  static bool _isPureString(String arg) {
+    final t = arg.trim();
+    return (t.startsWith('"') && t.endsWith('"') && t.length >= 2) ||
+        (t.startsWith("'") && t.endsWith("'") && t.length >= 2);
+  }
+
+  /// Extracts the [argIndex]-th positional argument (0-based) from the
+  /// argument list starting at [start] in [content].  Tracks nested
+  /// parentheses and string literals so that commas inside them are not
+  /// treated as argument separators.
+  static String? _extractArg(String content, int start, int argIndex) {
+    var depth = 0;
+    var inSingle = false;
+    var inDouble = false;
+    var argStart = start;
+    var currentArg = 0;
+
+    for (var i = start; i < content.length; i++) {
+      final ch = content[i];
+      if (ch == "'" && !inDouble) {
+        inSingle = !inSingle;
+      } else if (ch == '"' && !inSingle) {
+        inDouble = !inDouble;
+      } else if (!inSingle && !inDouble) {
+        if (ch == '(') {
+          depth++;
+        } else if (ch == ')') {
+          if (depth == 0) {
+            // End of call — return the current arg if it is the target.
+            if (currentArg == argIndex) {
+              return content.substring(argStart, i);
+            }
+            return null;
+          }
+          depth--;
+        } else if (ch == ',' && depth == 0) {
+          if (currentArg == argIndex) {
+            return content.substring(argStart, i);
+          }
+          currentArg++;
+          argStart = i + 1;
+        }
       }
     }
+    return null;
   }
 
   /// Converts a character offset in joined [lines] (separated by '\n') to a

--- a/test/utils/key_extractor_test.dart
+++ b/test/utils/key_extractor_test.dart
@@ -83,18 +83,18 @@ void main() {
     });
 
     test('allows custom maxSuffix', () {
-      expect(KeyExtractor.normalizePlural('error-404', maxSuffix: 999),
-          'error');
+      expect(
+          KeyExtractor.normalizePlural('error-404', maxSuffix: 999), 'error');
     });
   });
 
-    test('skips null values', () {
-      final map = {
-        'title': 'Hello',
-        'nullable': null,
-        'nested': {'valid': 'OK', 'alsoNull': null},
-      };
-      final keys = KeyExtractor.extract(map);
-      expect(keys, {'title', 'nested.valid'});
-    });
+  test('skips null values', () {
+    final map = {
+      'title': 'Hello',
+      'nullable': null,
+      'nested': {'valid': 'OK', 'alsoNull': null},
+    };
+    final keys = KeyExtractor.extract(map);
+    expect(keys, {'title', 'nested.valid'});
+  });
 }

--- a/test/utils/key_extractor_test.dart
+++ b/test/utils/key_extractor_test.dart
@@ -1,0 +1,100 @@
+import 'package:flutter_test/flutter_test.dart';
+
+import '../../bin/utils/key_extractor.dart';
+
+void main() {
+  group('KeyExtractor', () {
+    test('extracts keys from flat map', () {
+      final map = {'title': 'Hello', 'subtitle': 'World'};
+      final keys = KeyExtractor.extract(map);
+      expect(keys, {'title', 'subtitle'});
+    });
+
+    test('extracts nested dotted keys', () {
+      final map = {
+        'home': {
+          'title': 'Home',
+          'nested': {'deep': 'Deep Value'},
+        },
+        'profile': {'name': 'Profile'},
+      };
+      final keys = KeyExtractor.extract(map);
+      expect(keys, {
+        'home.title',
+        'home.nested.deep',
+        'profile.name',
+      });
+    });
+
+    test('extracts scalar leaf values (String, int, double, bool)', () {
+      final map = {
+        'title': 'Hello',
+        'list': ['a', 'b'],
+        'count': 42,
+        'price': 9.99,
+        'enabled': true,
+        'nested': {'valid': 'OK', 'flag': false},
+      };
+      final keys = KeyExtractor.extract(map);
+      expect(keys, {
+        'title',
+        'count',
+        'price',
+        'enabled',
+        'nested.valid',
+        'nested.flag',
+      });
+    });
+
+    test('returns empty set for empty map', () {
+      expect(KeyExtractor.extract({}), isEmpty);
+    });
+
+    test('skips List and Set but extracts scalar values from nested Maps', () {
+      final map = {
+        'a': [1, 2],
+        'b': {'c': 3},
+        'd': {1, 2, 3},
+      };
+      final keys = KeyExtractor.extract(map);
+      expect(keys, {'b.c'});
+    });
+  });
+
+  group('normalizePlural', () {
+    test('strips plural suffix', () {
+      expect(KeyExtractor.normalizePlural('clicked.times-0'), 'clicked.times');
+      expect(KeyExtractor.normalizePlural('home.list-12'), 'home.list');
+    });
+
+    test('returns null for non-plural keys', () {
+      expect(KeyExtractor.normalizePlural('home.title'), isNull);
+      expect(KeyExtractor.normalizePlural('a-b-c'), isNull);
+    });
+
+    test('returns null for hyphen without numeric suffix', () {
+      expect(KeyExtractor.normalizePlural('clicked.times-'), isNull);
+      expect(KeyExtractor.normalizePlural('clicked.times-abc'), isNull);
+    });
+
+    test('returns null for large numeric suffix (non-plural)', () {
+      expect(KeyExtractor.normalizePlural('error-404'), isNull);
+      expect(KeyExtractor.normalizePlural('section-100'), isNull);
+    });
+
+    test('allows custom maxSuffix', () {
+      expect(KeyExtractor.normalizePlural('error-404', maxSuffix: 999),
+          'error');
+    });
+  });
+
+    test('skips null values', () {
+      final map = {
+        'title': 'Hello',
+        'nullable': null,
+        'nested': {'valid': 'OK', 'alsoNull': null},
+      };
+      final keys = KeyExtractor.extract(map);
+      expect(keys, {'title', 'nested.valid'});
+    });
+}

--- a/test/utils/source_scanner_test.dart
+++ b/test/utils/source_scanner_test.dart
@@ -325,8 +325,7 @@ void main() {
       final result = SourceScanner.scan(tmpDir.path);
       expect(result.literalKeys, isEmpty);
       expect(result.dynamicRefs, isNotEmpty);
-      expect(result.dynamicRefs.first.lineContent,
-          contains('I18nText(key)'));
+      expect(result.dynamicRefs.first.lineContent, contains('I18nText(key)'));
     });
 
     test('detects dynamic key in I18nPlural', () {
@@ -337,8 +336,8 @@ void main() {
       final result = SourceScanner.scan(tmpDir.path);
       expect(result.literalKeys, isEmpty);
       expect(result.dynamicRefs, isNotEmpty);
-      expect(result.dynamicRefs.first.lineContent,
-          contains('I18nPlural(key, n)'));
+      expect(
+          result.dynamicRefs.first.lineContent, contains('I18nPlural(key, n)'));
     });
 
     test('scans only specified scanPaths', () {

--- a/test/utils/source_scanner_test.dart
+++ b/test/utils/source_scanner_test.dart
@@ -391,5 +391,33 @@ void main() {
       expect(result.namespaceConfigs[1].basePath, isNull);
       expect(result.namespaceConfigs[1].namespaces, ['home']);
     });
+
+    test('extracts literal keys from ternary branches, still flags dynamic',
+        () {
+      writeDartFile('a.dart', '''
+        import 'package:flutter_i18n/flutter_i18n.dart';
+        void f(BuildContext c, bool cond) {
+          FlutterI18n.translate(c, cond ? "key.true" : "key.false");
+        }
+      ''');
+      final result = SourceScanner.scan(tmpDir.path);
+      expect(result.literalKeys, containsAll(['key.true', 'key.false']));
+      expect(result.dynamicRefs, isNotEmpty);
+      expect(result.dynamicRefs.first.lineContent,
+          contains('FlutterI18n.translate'));
+    });
+
+    test('extracts literal key from ternary with one hardcoded branch', () {
+      writeDartFile('a.dart', '''
+        import 'package:flutter_i18n/flutter_i18n.dart';
+        void f(BuildContext c, String fallback) {
+          FlutterI18n.translate(c, cond ? "key.if" : fallback);
+        }
+      ''');
+      final result = SourceScanner.scan(tmpDir.path);
+      expect(result.literalKeys, contains('key.if'));
+      expect(result.literalKeys, isNot(contains('fallback')));
+      expect(result.dynamicRefs, isNotEmpty);
+    });
   });
 }

--- a/test/utils/source_scanner_test.dart
+++ b/test/utils/source_scanner_test.dart
@@ -1,0 +1,395 @@
+import 'dart:io';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:path/path.dart' as p;
+
+import '../../bin/utils/source_scanner.dart';
+
+void main() {
+  late Directory tmpDir;
+  late String libDir;
+
+  setUp(() {
+    tmpDir = Directory.systemTemp.createTempSync('source_scanner_test_');
+    libDir = p.join(tmpDir.path, 'lib');
+    Directory(libDir).createSync();
+  });
+
+  tearDown(() {
+    tmpDir.deleteSync(recursive: true);
+  });
+
+  void writeDartFile(String name, String content) {
+    File(p.join(libDir, name)).writeAsStringSync(content);
+  }
+
+  group('SourceScanner', () {
+    test('finds FlutterI18n.translate with double quotes', () {
+      writeDartFile('a.dart', '''
+        import 'package:flutter_i18n/flutter_i18n.dart';
+        void f(BuildContext context) {
+          FlutterI18n.translate(context, "home.title");
+        }
+      ''');
+      final result = SourceScanner.scan(tmpDir.path);
+      expect(result.literalKeys, contains('home.title'));
+      expect(result.dynamicRefs, isEmpty);
+    });
+
+    test('finds FlutterI18n.translate with single quotes', () {
+      writeDartFile('a.dart', '''
+        import 'package:flutter_i18n/flutter_i18n.dart';
+        void f(BuildContext context) {
+          FlutterI18n.translate(context, 'settings.general');
+        }
+      ''');
+      final result = SourceScanner.scan(tmpDir.path);
+      expect(result.literalKeys, contains('settings.general'));
+    });
+
+    test('finds FlutterI18n.plural', () {
+      writeDartFile('a.dart', '''
+        import 'package:flutter_i18n/flutter_i18n.dart';
+        void f(BuildContext context) {
+          FlutterI18n.plural(context, "clicked.times", n);
+        }
+      ''');
+      final result = SourceScanner.scan(tmpDir.path);
+      expect(result.literalKeys, contains('clicked.times'));
+    });
+
+    test('finds I18nText widget', () {
+      writeDartFile('a.dart', '''
+        import 'package:flutter_i18n/flutter_i18n.dart';
+        Widget b() => I18nText("home.title");
+      ''');
+      final result = SourceScanner.scan(tmpDir.path);
+      expect(result.literalKeys, contains('home.title'));
+    });
+
+    test('finds I18nPlural widget', () {
+      writeDartFile('a.dart', '''
+        import 'package:flutter_i18n/flutter_i18n.dart';
+        Widget b() => I18nPlural("clicked.times", 3);
+      ''');
+      final result = SourceScanner.scan(tmpDir.path);
+      expect(result.literalKeys, contains('clicked.times'));
+    });
+
+    test('finds fallbackKey', () {
+      writeDartFile('a.dart', '''
+        import 'package:flutter_i18n/flutter_i18n.dart';
+        void f(BuildContext context) {
+          FlutterI18n.translate(context, "home.new",
+              fallbackKey: "common.ok");
+        }
+      ''');
+      final result = SourceScanner.scan(tmpDir.path);
+      expect(result.literalKeys, contains('home.new'));
+      expect(result.literalKeys, contains('common.ok'));
+    });
+
+    test('handles import alias prefix', () {
+      writeDartFile('a.dart', '''
+        import 'package:flutter_i18n/flutter_i18n.dart' as i18n;
+        void f(BuildContext context) {
+          i18n.FlutterI18n.translate(context, "home.title");
+          i18n.I18nText("profile.name");
+        }
+      ''');
+      final result = SourceScanner.scan(tmpDir.path);
+      expect(result.literalKeys, contains('home.title'));
+      expect(result.literalKeys, contains('profile.name'));
+    });
+
+    test('handles arbitrary import prefix', () {
+      writeDartFile('a.dart', '''
+        import 'package:flutter_i18n/flutter_i18n.dart' as my_i18n;
+        void f(BuildContext context) {
+          my_i18n.FlutterI18n.plural(context, "items.count", 5);
+        }
+      ''');
+      final result = SourceScanner.scan(tmpDir.path);
+      expect(result.literalKeys, contains('items.count'));
+    });
+
+    test('skips commented-out calls', () {
+      writeDartFile('a.dart', '''
+        void f(BuildContext context) {
+          // FlutterI18n.translate(context, "commented.key");
+          FlutterI18n.translate(context, "active.key");
+        }
+      ''');
+      final result = SourceScanner.scan(tmpDir.path);
+      expect(result.literalKeys, contains('active.key'));
+      expect(result.literalKeys, isNot(contains('commented.key')));
+    });
+
+    test('detects dynamic keys (variable reference)', () {
+      writeDartFile('a.dart', '''
+        void f(BuildContext context, String key) {
+          FlutterI18n.translate(context, key);
+        }
+      ''');
+      final result = SourceScanner.scan(tmpDir.path);
+      expect(result.literalKeys, isEmpty);
+      expect(result.dynamicRefs, isNotEmpty);
+      expect(result.dynamicRefs.first.lineContent,
+          contains('FlutterI18n.translate(context, key)'));
+    });
+
+    test('detects dynamic keys (string interpolation)', () {
+      writeDartFile('a.dart', '''
+        void f(BuildContext context) {
+          FlutterI18n.translate(context, "home.\\\${section}");
+        }
+      ''');
+      final result = SourceScanner.scan(tmpDir.path);
+      expect(result.literalKeys, isEmpty);
+      expect(result.dynamicRefs, isNotEmpty);
+    });
+
+    test('collects multiple keys from one file', () {
+      writeDartFile('a.dart', '''
+        void f(BuildContext c) {
+          FlutterI18n.translate(c, "a.b");
+          FlutterI18n.plural(c, "c.d", 1);
+        }
+        Widget g() => I18nText("e.f");
+      ''');
+      final result = SourceScanner.scan(tmpDir.path);
+      expect(result.literalKeys, containsAll(['a.b', 'c.d', 'e.f']));
+    });
+
+    test('does not match unrelated names', () {
+      writeDartFile('a.dart', '''
+        void f() {
+          SomeOther.translate("not.a.key");
+          MyFlutterI18n.translate(ctx, "also.not");
+          I18nSomething("wrong.widget");
+        }
+      ''');
+      final result = SourceScanner.scan(tmpDir.path);
+      expect(result.literalKeys, isEmpty);
+    });
+
+    test('handles extra whitespace in calls', () {
+      writeDartFile('a.dart', '''
+        void f(BuildContext c) {
+          FlutterI18n . translate ( c , "key.with.spaces" ) ;
+          I18nText   (   "padded.key"   );
+          FlutterI18n . plural (c, "plural.spaces", 1);
+        }
+      ''');
+      final result = SourceScanner.scan(tmpDir.path);
+      expect(result.literalKeys,
+          containsAll(['key.with.spaces', 'padded.key', 'plural.spaces']));
+    });
+
+    test('includes file path and line in dynamic refs', () {
+      writeDartFile('a.dart', '''
+        void f(BuildContext c) {
+          FlutterI18n.translate(c, dynamicVar);
+        }
+      ''');
+      final result = SourceScanner.scan(tmpDir.path);
+      expect(result.dynamicRefs, hasLength(1));
+      expect(result.dynamicRefs.first.filePath, endsWith('.dart'));
+      expect(result.dynamicRefs.first.line, equals(2));
+    });
+
+    test('scans multiple files', () {
+      writeDartFile('a.dart', '''
+        void f(BuildContext c) { FlutterI18n.translate(c, "file.a.key"); }
+      ''');
+      writeDartFile('b.dart', '''
+        Widget g() => I18nText("file.b.key");
+      ''');
+      final result = SourceScanner.scan(tmpDir.path);
+      expect(result.literalKeys, containsAll(['file.a.key', 'file.b.key']));
+    });
+
+    test('handles // inside string literal (URL)', () {
+      writeDartFile('a.dart', '''
+        void f(BuildContext c) {
+          FlutterI18n.translate(c, "http://example.com/title");
+        }
+      ''');
+      final result = SourceScanner.scan(tmpDir.path);
+      expect(result.literalKeys, contains('http://example.com/title'));
+    });
+
+    test('does not match key after // comment on same line', () {
+      writeDartFile('a.dart', '''
+        void f(BuildContext c) {
+          FlutterI18n.translate(c, "live.key"); // FlutterI18n.translate(c, "dead.key")
+        }
+      ''');
+      final result = SourceScanner.scan(tmpDir.path);
+      expect(result.literalKeys, contains('live.key'));
+      expect(result.literalKeys, isNot(contains('dead.key')));
+    });
+
+    test('scans dart files outside lib/ directory', () {
+      final testDir = p.join(tmpDir.path, 'test');
+      Directory(testDir).createSync();
+      writeDartFile('a.dart', '''
+        void f(BuildContext c) { FlutterI18n.translate(c, "lib.key"); }
+      ''');
+      File(p.join(testDir, 'b.dart')).writeAsStringSync('''
+        void f(BuildContext c) { FlutterI18n.translate(c, "test.key"); }
+      ''');
+      final result = SourceScanner.scan(tmpDir.path);
+      expect(result.literalKeys, containsAll(['lib.key', 'test.key']));
+    });
+
+    test('extracts literal key from multi-line FlutterI18n.translate', () {
+      writeDartFile('a.dart', '''
+        void f(BuildContext c) {
+          FlutterI18n.translate(
+            c,
+            "multi.line.key"
+          );
+        }
+      ''');
+      final result = SourceScanner.scan(tmpDir.path);
+      expect(result.literalKeys, contains('multi.line.key'));
+      expect(result.dynamicRefs, isEmpty);
+    });
+
+    test('captures multiple literal keys on same line', () {
+      writeDartFile('a.dart', '''
+        void f(BuildContext c) {
+          I18nText("first.key"); I18nText("second.key");
+        }
+      ''');
+      final result = SourceScanner.scan(tmpDir.path);
+      expect(result.literalKeys, containsAll(['first.key', 'second.key']));
+    });
+
+    test('finds fallbackKey with single quotes', () {
+      writeDartFile('a.dart', '''
+        import 'package:flutter_i18n/flutter_i18n.dart';
+        void f(BuildContext context) {
+          FlutterI18n.translate(context, "home.new",
+              fallbackKey: 'common.ok');
+        }
+      ''');
+      final result = SourceScanner.scan(tmpDir.path);
+      expect(result.literalKeys, contains('home.new'));
+      expect(result.literalKeys, contains('common.ok'));
+    });
+
+    test('extracts multiline I18nText key', () {
+      writeDartFile('a.dart', '''
+        import 'package:flutter_i18n/flutter_i18n.dart';
+        Widget b() => I18nText(
+          "multiline.widget.key"
+        );
+      ''');
+      final result = SourceScanner.scan(tmpDir.path);
+      expect(result.literalKeys, contains('multiline.widget.key'));
+    });
+
+    test('extracts multiline I18nPlural key', () {
+      writeDartFile('a.dart', '''
+        import 'package:flutter_i18n/flutter_i18n.dart';
+        Widget b() => I18nPlural(
+          "multiline.plural.key",
+          3,
+        );
+      ''');
+      final result = SourceScanner.scan(tmpDir.path);
+      expect(result.literalKeys, contains('multiline.plural.key'));
+    });
+
+    test('skips commented-out fallbackKey', () {
+      writeDartFile('a.dart', '''
+        import 'package:flutter_i18n/flutter_i18n.dart';
+        void f(BuildContext context) {
+          FlutterI18n.translate(context, "live.key");
+          // FlutterI18n.translate(context, "dead.key", fallbackKey: "dead.fb");
+        }
+      ''');
+      final result = SourceScanner.scan(tmpDir.path);
+      expect(result.literalKeys, contains('live.key'));
+      expect(result.literalKeys, isNot(contains('dead.key')));
+      expect(result.literalKeys, isNot(contains('dead.fb')));
+    });
+
+    test('detects dynamic key in I18nText', () {
+      writeDartFile('a.dart', '''
+        import 'package:flutter_i18n/flutter_i18n.dart';
+        Widget b(String key) => I18nText(key);
+      ''');
+      final result = SourceScanner.scan(tmpDir.path);
+      expect(result.literalKeys, isEmpty);
+      expect(result.dynamicRefs, isNotEmpty);
+      expect(result.dynamicRefs.first.lineContent,
+          contains('I18nText(key)'));
+    });
+
+    test('detects dynamic key in I18nPlural', () {
+      writeDartFile('a.dart', '''
+        import 'package:flutter_i18n/flutter_i18n.dart';
+        Widget b(String key, int n) => I18nPlural(key, n);
+      ''');
+      final result = SourceScanner.scan(tmpDir.path);
+      expect(result.literalKeys, isEmpty);
+      expect(result.dynamicRefs, isNotEmpty);
+      expect(result.dynamicRefs.first.lineContent,
+          contains('I18nPlural(key, n)'));
+    });
+
+    test('scans only specified scanPaths', () {
+      final testDir = p.join(tmpDir.path, 'test');
+      Directory(testDir).createSync();
+      File(p.join(libDir, 'a.dart')).writeAsStringSync('''
+        void f(BuildContext c) { FlutterI18n.translate(c, "lib.key"); }
+      ''');
+      File(p.join(testDir, 'b.dart')).writeAsStringSync('''
+        void f(BuildContext c) { FlutterI18n.translate(c, "test.key"); }
+      ''');
+      final result = SourceScanner.scan(
+        tmpDir.path,
+        scanPaths: ['lib'],
+      );
+      expect(result.literalKeys, contains('lib.key'));
+      expect(result.literalKeys, isNot(contains('test.key')));
+    });
+
+    test('extracts NamespaceConfig from source', () {
+      writeDartFile('a.dart', '''
+        import 'package:flutter_i18n/flutter_i18n.dart';
+        final loader = NamespaceFileTranslationLoader(
+          basePath: "assets/i18n",
+          namespaces: ["common", "home"],
+        );
+      ''');
+      final result = SourceScanner.scan(tmpDir.path);
+      expect(result.namespaceConfigs, hasLength(1));
+      expect(result.namespaceConfigs.first.basePath, 'assets/i18n');
+      expect(result.namespaceConfigs.first.namespaces,
+          containsAll(['common', 'home']));
+    });
+
+    test('extracts multiple NamespaceConfigs', () {
+      writeDartFile('a.dart', '''
+        import 'package:flutter_i18n/flutter_i18n.dart';
+        final a = NamespaceFileTranslationLoader(
+          basePath: "i18n/common",
+          namespaces: ["common"],
+        );
+        final b = NamespaceFileTranslationLoader(
+          namespaces: ["home"],
+        );
+      ''');
+      final result = SourceScanner.scan(tmpDir.path);
+      expect(result.namespaceConfigs, hasLength(2));
+      expect(result.namespaceConfigs[0].basePath, 'i18n/common');
+      expect(result.namespaceConfigs[0].namespaces, ['common']);
+      expect(result.namespaceConfigs[1].basePath, isNull);
+      expect(result.namespaceConfigs[1].namespaces, ['home']);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Add a new `unused` command that statically analyzes translation key coverage between Dart source code and translation asset files. It reports three categories: keys defined in translation files but never referenced in source (unused), keys referenced in source but missing from translation files (missing), and keys constructed dynamically that cannot be statically analyzed (dynamic).

Also fixes a root-cause bug in `retrieveAssetsContent()` where individual asset files listed in `pubspec.yaml` were silently skipped — this affected all three CLI commands (`validate`, `diff`, `unused`).

## Features

### `unused` command

Scans the project's Dart source code and translation asset files, then produces three reports:

- **Unused translation keys** — exist in translation files but never referenced in source
- **Missing translation keys** — referenced in source but not found in any translation file
- **Dynamic keys** — constructed with variables or expressions, cannot be analyzed statically

```sh
flutter pub run flutter_i18n unused              # terminal output
flutter pub run flutter_i18n unused --md         # generate markdown report
flutter pub run flutter_i18n unused --md --path=doc    # generate markdown report into `doc/`
flutter pub run flutter_i18n unused --scan=lib   # custom scan paths (default: lib, test)
```

### `SourceScanner` design

Uses **argument extraction + bracket matching** :

1. `_dynamicCallRe` locates all `FlutterI18n.translate/plural` and `I18nText/I18nPlural` call sites
2. `_findMatchingParen` finds the matching closing paren
3. `_extractArg` splits arguments by top-level commas, identifying the key argument position (index 1 for fluent API, index 0 for widget constructors)
4. Pure string literal key is added to `literalKeys`
5. Non-string key argument (variables, ternary `?:`, null-coalescing `??`, etc.) is scanned for hardcoded string literals inside the argument and they are added them to `literalKeys`, while also adding the call to `dynamicRefs`

### `KeyExtractor` design

- `extract()` — recursively flattens nested maps into dotted-path key sets, skipping `List`, `Set`, and `null` values
- `normalizePlural()` — strips plural suffixes, treating large numeric suffixes (>99) as non-plural

Close: #241